### PR TITLE
fix: ユーザーメッセージのコンテンツ表示を修正

### DIFF
--- a/src/api-mock.ts
+++ b/src/api-mock.ts
@@ -43,7 +43,7 @@ const mockMessages: ClaudeMessage[] = [
     session_id: "session-1",
     timestamp: "2025-07-20T10:00:00Z",
     message_type: "User",
-    content: { User: { role: "user", content: "Help me implement a React component for user authentication" } },
+    content: { role: "user", content: "Help me implement a React component for user authentication" },
     cwd: "/Users/developer/projects/web-app",
     git_branch: "main"
   },
@@ -52,7 +52,7 @@ const mockMessages: ClaudeMessage[] = [
     session_id: "session-1", 
     timestamp: "2025-07-20T10:01:00Z",
     message_type: "Assistant",
-    content: { Assistant: { role: "assistant", content: [{ Text: { text: "I'll help you create a React authentication component. Let's start by setting up the basic structure..." } }] } },
+    content: { role: "assistant", content: [{ type: "text", text: "I'll help you create a React authentication component. Let's start by setting up the basic structure..." }] },
     cwd: "/Users/developer/projects/web-app",
     git_branch: "main"
   }

--- a/src/components/SessionBrowser.tsx
+++ b/src/components/SessionBrowser.tsx
@@ -83,20 +83,20 @@ export const SessionBrowser: React.FC<SessionBrowserProps> = () => {
 
   const renderMessageContent = (message: ClaudeMessage) => {
     if (message.message_type === 'User') {
-      const content = (message.content as any).User?.content || '';
+      const content = typeof message.content.content === 'string' ? message.content.content : '';
       return <div className="message-content user-content">{content}</div>;
     } else {
-      const content = (message.content as any).Assistant?.content || [];
+      const content = Array.isArray(message.content.content) ? message.content.content : [];
       return (
         <div className="message-content assistant-content">
-          {content.map((block: any, index: number) => {
-            if (block.Text) {
-              return <div key={index} className="text-block">{block.Text.text}</div>;
-            } else if (block.ToolUse) {
+          {content.map((block, index) => {
+            if (block.type === 'text') {
+              return <div key={index} className="text-block">{block.text}</div>;
+            } else if (block.type === 'tool_use') {
               return (
                 <div key={index} className="tool-use-block">
-                  <strong>Tool: {block.ToolUse.name}</strong>
-                  <pre>{JSON.stringify(block.ToolUse.input, null, 2)}</pre>
+                  <strong>Tool: {block.name}</strong>
+                  <pre>{JSON.stringify(block.input, null, 2)}</pre>
                 </div>
               );
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,18 +13,18 @@ export interface ClaudeMessage {
   session_id: string;
   timestamp: string;
   message_type: 'User' | 'Assistant';
-  content: MessageContent;
+  content: {
+    role: string;
+    content: string | ContentBlock[];
+  };
   cwd: string;
   git_branch?: string;
 }
 
-export type MessageContent = 
-  | { User: { role: string; content: string } }
-  | { Assistant: { role: string; content: ContentBlock[] } };
 
 export type ContentBlock = 
-  | { Text: { text: string } }
-  | { ToolUse: { id: string; name: string; input: any } };
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: any };
 
 export interface TodoItem {
   id: string;


### PR DESCRIPTION
## Summary
SessionBrowserでrole="user"のメッセージコンテンツが正しく表示されない問題(Issue #3)を修正しました。

## Changes
- TypeScript型定義をRustバックエンドの実際のシリアライゼーション構造に合わせて修正
- `renderMessageContent`関数でユーザーメッセージが適切に表示されるよう改善
- Mock APIデータも新しい構造に合わせて更新

## Technical Details
Rustバックエンドは`#[serde(untagged)]`でMessageContentをシリアライズしているため、実際のJSONは:
```json
{
  "role": "user", 
  "content": "メッセージ内容"
}
```
の形式になります。以前のTypeScript型定義では`{ User: { role, content } }`を期待していましたが、実際の構造に合わせて修正しました。

## Test plan
- [x] TypeScriptコンパイルエラーの解消確認
- [x] Mock APIでのユーザーメッセージ表示テスト
- [x] Assistantメッセージの表示が引き続き正常に動作することを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)