### PR TITLE
fix: prevent session list from disappearing with long text

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -254,7 +254,7 @@ body {
 
 .session-browser-content {
   display: grid;
-  grid-template-columns: 1fr 2fr;
+  grid-template-columns: minmax(250px, 1fr) minmax(400px, 2fr);
   gap: 2rem;
   height: calc(100vh - 200px);
   overflow: hidden;
@@ -396,6 +396,9 @@ body {
 .content-text {
   white-space: pre-wrap;
   word-wrap: break-word;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  max-width: 100%;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;


### PR DESCRIPTION
## Summary
- Fixes issue where session list disappears when messages panel contains long text
- Sets minimum widths for grid columns using `minmax()` function
- Adds stronger text wrapping properties for content overflow

## Changes
- Session list gets minimum 250px width, messages panel gets minimum 400px
- Added `word-break: break-word`, `overflow-wrap: break-word`, and `max-width: 100%` to `.content-text`

## Test plan
- [x] Open a session with very long text content (URLs, code without spaces)
- [x] Verify session list remains visible at 250px minimum width
- [x] Verify long text wraps properly without horizontal overflow

🤖 Generated with [Claude Code](https://claude.ai/code)