### PR TITLE
feat: Dashboardのprojectクリックでsessionsタブにナビゲート

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -163,6 +163,17 @@ body {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
+.project-card.clickable {
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.project-card.clickable:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  border-left: 4px solid #3498db;
+}
+
 .project-card h4 {
   color: #2c3e50;
   margin-bottom: 0.5rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,18 +10,25 @@ type Tab = "dashboard" | "sessions" | "commands" | "todos" | "settings";
 
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>("dashboard");
+  const [sessionProjectFilter, setSessionProjectFilter] =
+    useState<string>("all");
 
   // File watcher and real-time updates disabled
   // useEffect(() => {
   //   // File watcher functionality removed
   // }, []);
 
+  const navigateToSessionsWithProject = (projectPath: string) => {
+    setSessionProjectFilter(projectPath);
+    setActiveTab("sessions");
+  };
+
   const renderActiveTab = () => {
     switch (activeTab) {
       case "dashboard":
-        return <Dashboard />;
+        return <Dashboard onProjectClick={navigateToSessionsWithProject} />;
       case "sessions":
-        return <SessionBrowser />;
+        return <SessionBrowser initialProjectFilter={sessionProjectFilter} />;
       case "commands":
         return <CommandHistory />;
       case "todos":
@@ -29,7 +36,7 @@ function App() {
       case "settings":
         return <SettingsEditor />;
       default:
-        return <Dashboard />;
+        return <Dashboard onProjectClick={navigateToSessionsWithProject} />;
     }
   };
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState, useCallback } from "react";
 import { api } from "../api";
 import type { SessionStats, ProjectSummary } from "../types";
 
-interface DashboardProps {}
+interface DashboardProps {
+  onProjectClick?: (projectPath: string) => void;
+}
 
-export const Dashboard: React.FC<DashboardProps> = () => {
+export const Dashboard: React.FC<DashboardProps> = ({ onProjectClick }) => {
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -121,7 +123,11 @@ export const Dashboard: React.FC<DashboardProps> = () => {
         ) : (
           <div className="projects-list">
             {projects.slice(0, 10).map((project) => (
-              <div key={project.project_path} className="project-card">
+              <div
+                key={project.project_path}
+                className="project-card clickable"
+                onClick={() => onProjectClick?.(project.project_path)}
+              >
                 <h4>
                   {project.project_path.split("/").pop() ||
                     project.project_path}

--- a/src/components/SessionBrowser.tsx
+++ b/src/components/SessionBrowser.tsx
@@ -3,9 +3,13 @@ import { marked } from "marked";
 import { api } from "../api";
 import type { ClaudeSession, ClaudeMessage, ContentBlock } from "../types";
 
-interface SessionBrowserProps {}
+interface SessionBrowserProps {
+  initialProjectFilter?: string;
+}
 
-export const SessionBrowser: React.FC<SessionBrowserProps> = () => {
+export const SessionBrowser: React.FC<SessionBrowserProps> = ({
+  initialProjectFilter = "all",
+}) => {
   const [sessions, setSessions] = useState<ClaudeSession[]>([]);
   const [allSessions, setAllSessions] = useState<ClaudeSession[]>([]);
   const [selectedSession, setSelectedSession] = useState<ClaudeSession | null>(
@@ -13,7 +17,8 @@ export const SessionBrowser: React.FC<SessionBrowserProps> = () => {
   );
   const [messages, setMessages] = useState<ClaudeMessage[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedProject, setSelectedProject] = useState<string>("all");
+  const [selectedProject, setSelectedProject] =
+    useState<string>(initialProjectFilter);
   const [projects, setProjects] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMessages, setLoadingMessages] = useState(false);
@@ -154,7 +159,7 @@ export const SessionBrowser: React.FC<SessionBrowserProps> = () => {
 
   const refreshAllSessions = async () => {
     const currentSessionId = selectedSession?.session_id;
-    
+
     try {
       setLoading(true);
       setError(null);
@@ -173,7 +178,9 @@ export const SessionBrowser: React.FC<SessionBrowserProps> = () => {
       // Refresh messages if a session is selected
       if (currentSessionId) {
         // Find the updated session data
-        const updatedSession = data.find(s => s.session_id === currentSessionId);
+        const updatedSession = data.find(
+          (s) => s.session_id === currentSessionId,
+        );
         if (updatedSession) {
           await loadSessionMessages(updatedSession);
         }


### PR DESCRIPTION
close #33 
## Summary
- Dashboardのプロジェクトカードをクリックすると、Sessionsタブに遷移し、該当プロジェクトでフィルタリングされるように実装
- プロジェクトカードにホバーエフェクトとクリック可能なスタイルを追加
- App.tsxでプロジェクトフィルタ状態管理機能を追加

## Test plan
- [x] TypeScriptコンパイルが成功することを確認
- [x] 既存のテストがすべてパスすることを確認  
- [x] Rustリンティング（cargo clippy）がパスすることを確認
- [x] プロジェクトカードのクリック機能とナビゲーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)