### PR TITLE
feat: DashboardのRecent Projectsに最新メッセージを表示

### DIFF
--- a/src-tauri/src/claude_data.rs
+++ b/src-tauri/src/claude_data.rs
@@ -616,12 +616,14 @@ impl ClaudeDataManager {
                     last_activity: session.updated_at,
                     total_messages: 0,
                     active_todos: 0,
+                    latest_message: None,
                 });
 
             entry.session_count += 1;
             entry.total_messages += session.message_count;
             if session.updated_at > entry.last_activity {
                 entry.last_activity = session.updated_at;
+                entry.latest_message = session.latest_content_preview.clone();
             }
         }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -165,6 +165,7 @@ pub struct ProjectSummary {
     pub last_activity: DateTime<Utc>,
     pub total_messages: usize,
     pub active_todos: usize,
+    pub latest_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -219,11 +219,16 @@ mod tests {
             last_activity: chrono::Utc::now(),
             total_messages: 100,
             active_todos: 3,
+            latest_message: Some("Latest message preview".to_string()),
         };
 
         assert_eq!(summary.session_count, 5);
         assert_eq!(summary.total_messages, 100);
         assert_eq!(summary.active_todos, 3);
+        assert_eq!(
+            summary.latest_message,
+            Some("Latest message preview".to_string())
+        );
     }
 
     fn create_realistic_session_file(claude_dir: &Path, project_name: &str, session_id: &str) {

--- a/src/App.css
+++ b/src/App.css
@@ -199,6 +199,17 @@ body {
   border-radius: 4px;
 }
 
+.latest-message {
+  font-size: 0.8rem;
+  color: #555;
+  margin-bottom: 0.5rem;
+  font-style: italic;
+  background: #f8f9fa;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border-left: 3px solid #3498db;
+}
+
 .last-activity {
   font-size: 0.8rem;
   color: #7f8c8d;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -138,6 +138,11 @@ export const Dashboard: React.FC<DashboardProps> = ({ onProjectClick }) => {
                   <span>{project.total_messages} messages</span>
                   <span>{project.active_todos} TODOs</span>
                 </div>
+                {project.latest_message && (
+                  <p className="latest-message">
+                    Latest: {project.latest_message}
+                  </p>
+                )}
                 <p className="last-activity">
                   Last activity:{" "}
                   {new Date(project.last_activity).toLocaleDateString()}

--- a/src/tests/Dashboard.test.tsx
+++ b/src/tests/Dashboard.test.tsx
@@ -42,6 +42,7 @@ describe("Dashboard", () => {
         last_activity: "2025-07-20T10:00:00Z",
         total_messages: 50,
         active_todos: 2,
+        latest_message: "This is the latest message from project1",
       },
       {
         project_path: "/test/project2",
@@ -49,6 +50,7 @@ describe("Dashboard", () => {
         last_activity: "2025-07-19T15:30:00Z",
         total_messages: 30,
         active_todos: 1,
+        latest_message: "Latest message for project2",
       },
     ];
 
@@ -73,6 +75,14 @@ describe("Dashboard", () => {
     // Check projects are displayed
     expect(screen.getByText("project1")).toBeInTheDocument();
     expect(screen.getByText("project2")).toBeInTheDocument();
+
+    // Check latest messages are displayed
+    expect(
+      screen.getByText("Latest: This is the latest message from project1"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Latest: Latest message for project2"),
+    ).toBeInTheDocument();
   });
 
   it("handles error state", async () => {
@@ -121,5 +131,38 @@ describe("Dashboard", () => {
 
     expect(mockApi.getSessionStats).toHaveBeenCalledTimes(2);
     expect(mockApi.getProjectSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles projects without latest message", async () => {
+    const mockStats = {
+      total_sessions: 5,
+      total_messages: 50,
+      total_commands: 25,
+      active_projects: 2,
+      pending_todos: 3,
+    };
+
+    const mockProjects = [
+      {
+        project_path: "/test/project3",
+        session_count: 2,
+        last_activity: "2025-07-18T12:00:00Z",
+        total_messages: 20,
+        active_todos: 0,
+        // No latest_message field
+      },
+    ];
+
+    mockApi.getSessionStats.mockResolvedValue(mockStats);
+    mockApi.getProjectSummary.mockResolvedValue(mockProjects);
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("project3")).toBeInTheDocument();
+    });
+
+    // Check that no "Latest:" text is displayed for projects without latest_message
+    expect(screen.queryByText(/Latest:/)).not.toBeInTheDocument();
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,7 @@ export interface ProjectSummary {
   last_activity: string;
   total_messages: number;
   active_todos: number;
+  latest_message?: string;
 }
 
 export interface SessionStats {


### PR DESCRIPTION
## Summary
- ProjectSummaryにlatest_messageフィールドを追加し、各プロジェクトの最新セッションメッセージを表示
- Dashboardコンポーネントで最新メッセージプレビューを視覚的に表示
- テストケースを追加して機能の動作を保証

## Test plan
- [x] React/TypeScriptテストが全て通過
- [x] Rustテストが全て通過  
- [x] TypeScript型チェックが通過
- [x] Cargoリンティングが通過
- [x] 最新メッセージが存在するプロジェクトで適切に表示される
- [x] 最新メッセージが存在しないプロジェクトで表示されない
- [x] CSSスタイリングで見やすく表示される

close #22

🤖 Generated with [Claude Code](https://claude.ai/code)