### PR TITLE
feat: .claudeディレクトリ情報表示機能を追加

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -153,6 +153,16 @@ pub async fn activate_ide_window(
 // pub async fn start_file_watcher(...) -> Result<(), String> { ... }
 
 #[tauri::command]
+pub async fn get_project_claude_directories(
+    data_manager: State<'_, Arc<ClaudeDataManager>>,
+) -> Result<Vec<ProjectClaudeDirectory>, String> {
+    data_manager
+        .get_project_claude_directories()
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn open_session_file(
     session_id: String,
     data_manager: State<'_, Arc<ClaudeDataManager>>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ pub fn run() {
             search_commands,
             export_session_data,
             activate_ide_window,
+            get_project_claude_directories,
             open_session_file
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -175,3 +175,35 @@ pub struct SessionStats {
     pub active_projects: usize,
     pub pending_todos: usize,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeProjectInfo {
+    pub project_path: String,
+    pub has_claude_dir: bool,
+    pub commands: Vec<String>,
+    pub settings_local: Option<serde_json::Value>,
+    pub settings: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectClaudeDirectory {
+    pub project_path: String,
+    pub claude_dir_path: String,
+    pub exists: bool,
+    pub commands_dir: Option<CommandsDirectory>,
+    pub settings_local: Option<serde_json::Value>,
+    pub settings: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandsDirectory {
+    pub path: String,
+    pub commands: Vec<CommandFile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandFile {
+    pub name: String,
+    pub path: String,
+    pub content: String,
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,15 @@ import { SessionBrowser } from "./components/SessionBrowser";
 import { CommandHistory } from "./components/CommandHistory";
 import { TodoManager } from "./components/TodoManager";
 import { SettingsEditor } from "./components/SettingsEditor";
+import ProjectClaudeDirectories from "./components/ProjectClaudeDirectories";
 
-type Tab = "dashboard" | "sessions" | "commands" | "todos" | "settings";
+type Tab =
+  | "dashboard"
+  | "sessions"
+  | "commands"
+  | "todos"
+  | "settings"
+  | "claude-dirs";
 
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>("dashboard");
@@ -35,6 +42,8 @@ function App() {
         return <TodoManager />;
       case "settings":
         return <SettingsEditor />;
+      case "claude-dirs":
+        return <ProjectClaudeDirectories />;
       default:
         return <Dashboard onProjectClick={navigateToSessionsWithProject} />;
     }
@@ -74,6 +83,12 @@ function App() {
             onClick={() => setActiveTab("settings")}
           >
             Settings
+          </button>
+          <button
+            className={activeTab === "claude-dirs" ? "active" : ""}
+            onClick={() => setActiveTab("claude-dirs")}
+          >
+            .claude Dirs
           </button>
         </div>
       </nav>

--- a/src/api-mock.ts
+++ b/src/api-mock.ts
@@ -7,6 +7,7 @@ import type {
   ClaudeSettings,
   ProjectSummary,
   SessionStats,
+  ProjectClaudeDirectory,
 } from "./types";
 
 // Mock data for demonstration
@@ -245,5 +246,73 @@ export const mockApi = {
       return msg.session_id === sessionId;
     });
     return JSON.stringify(messages, null, 2);
+  },
+
+  async getProjectClaudeDirectories(): Promise<ProjectClaudeDirectory[]> {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return [
+      {
+        project_path: "/Users/developer/projects/web-app",
+        claude_dir_path: "/Users/developer/projects/web-app/.claude",
+        exists: true,
+        commands_dir: {
+          path: "/Users/developer/projects/web-app/.claude/commands",
+          commands: [
+            {
+              name: "build.md",
+              path: "/Users/developer/projects/web-app/.claude/commands/build.md",
+              content:
+                "# Build Command\n\nThis command builds the React application.\n\n```bash\nnpm run build\n```",
+            },
+            {
+              name: "test.md",
+              path: "/Users/developer/projects/web-app/.claude/commands/test.md",
+              content:
+                "# Test Command\n\nRuns all tests in the project.\n\n```bash\nnpm test\n```",
+            },
+          ],
+        },
+        settings_local: {
+          permissions: {
+            defaultMode: "accept",
+            allow: ["*"],
+            deny: [],
+          },
+        },
+        settings: {
+          hooks: {
+            PreToolUse: [],
+          },
+        },
+      },
+      {
+        project_path: "/Users/developer/projects/mobile-app",
+        claude_dir_path: "/Users/developer/projects/mobile-app/.claude",
+        exists: true,
+        commands_dir: {
+          path: "/Users/developer/projects/mobile-app/.claude/commands",
+          commands: [
+            {
+              name: "deploy.md",
+              path: "/Users/developer/projects/mobile-app/.claude/commands/deploy.md",
+              content:
+                "# Deploy Command\n\nDeploys the mobile app to staging.\n\n```bash\nreact-native run-android\n```",
+            },
+          ],
+        },
+        settings: {
+          permissions: {
+            defaultMode: "prompt",
+            allow: ["Read", "Write"],
+            deny: ["Bash"],
+          },
+        },
+      },
+      {
+        project_path: "/Users/developer/projects/api-server",
+        claude_dir_path: "/Users/developer/projects/api-server/.claude",
+        exists: false,
+      },
+    ];
   },
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,6 +7,7 @@ import type {
   ProjectSummary,
   SessionStats,
   IdeInfo,
+  ProjectClaudeDirectory,
 } from "./types";
 
 // Check if we're running in Tauri environment
@@ -131,6 +132,14 @@ export const api = {
     // Mock API doesn't support file operations
     console.log(`Would open JSONL file for session: ${sessionId}`);
     return Promise.resolve();
+  },
+
+  // Project .claude directories
+  async getProjectClaudeDirectories(): Promise<ProjectClaudeDirectory[]> {
+    if (isTauri && tauriApi) {
+      return tauriApi.invoke("get_project_claude_directories");
+    }
+    return mockApi.getProjectClaudeDirectories();
   },
 
   // Real-time monitoring

--- a/src/components/ProjectClaudeDirectories.tsx
+++ b/src/components/ProjectClaudeDirectories.tsx
@@ -1,0 +1,288 @@
+import React, { useState, useEffect } from "react";
+import { api } from "../api";
+import type { ProjectClaudeDirectory } from "../types";
+
+const ProjectClaudeDirectories: React.FC = () => {
+  const [directories, setDirectories] = useState<ProjectClaudeDirectory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
+    new Set(),
+  );
+
+  useEffect(() => {
+    loadDirectories();
+  }, []);
+
+  const loadDirectories = async () => {
+    try {
+      setLoading(true);
+      const data = await api.getProjectClaudeDirectories();
+      setDirectories(data);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to load project directories",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleProject = (projectPath: string) => {
+    const newExpanded = new Set(expandedProjects);
+    if (newExpanded.has(projectPath)) {
+      newExpanded.delete(projectPath);
+    } else {
+      newExpanded.add(projectPath);
+    }
+    setExpandedProjects(newExpanded);
+  };
+
+  const renderJsonValue = (value: any, key: string = ""): React.ReactNode => {
+    if (value === null || value === undefined) {
+      return <span className="text-gray-400">null</span>;
+    }
+
+    if (typeof value === "boolean") {
+      return (
+        <span className={value ? "text-green-600" : "text-red-600"}>
+          {value.toString()}
+        </span>
+      );
+    }
+
+    if (typeof value === "string") {
+      return <span className="text-blue-600">"{value}"</span>;
+    }
+
+    if (typeof value === "number") {
+      return <span className="text-purple-600">{value}</span>;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        return <span className="text-gray-400">[]</span>;
+      }
+      return (
+        <div className="ml-4">
+          <span className="text-gray-600">[</span>
+          {value.map((item, index) => (
+            <div key={index} className="ml-2">
+              {renderJsonValue(item, `${key}[${index}]`)}
+              {index < value.length - 1 && (
+                <span className="text-gray-600">,</span>
+              )}
+            </div>
+          ))}
+          <span className="text-gray-600">]</span>
+        </div>
+      );
+    }
+
+    if (typeof value === "object") {
+      const entries = Object.entries(value);
+      if (entries.length === 0) {
+        return <span className="text-gray-400">{"{}"}</span>;
+      }
+      return (
+        <div className="ml-4">
+          <span className="text-gray-600">{"{"}</span>
+          {entries.map(([k, v], index) => (
+            <div key={k} className="ml-2">
+              <span className="text-orange-600">"{k}"</span>
+              <span className="text-gray-600">: </span>
+              {renderJsonValue(v, `${key}.${k}`)}
+              {index < entries.length - 1 && (
+                <span className="text-gray-600">,</span>
+              )}
+            </div>
+          ))}
+          <span className="text-gray-600">{"}"}</span>
+        </div>
+      );
+    }
+
+    return <span>{String(value)}</span>;
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+        <span className="ml-3 text-gray-600">
+          Loading project .claude directories...
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+        <div className="flex items-center">
+          <div className="text-red-400">⚠️</div>
+          <div className="ml-3">
+            <h3 className="text-sm font-medium text-red-800">
+              Error loading directories
+            </h3>
+            <p className="text-sm text-red-600 mt-1">{error}</p>
+          </div>
+        </div>
+        <button
+          onClick={loadDirectories}
+          className="mt-3 px-3 py-1 bg-red-100 text-red-800 rounded text-sm hover:bg-red-200"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-gray-900">
+          Project .claude Directories
+        </h2>
+        <button
+          onClick={loadDirectories}
+          className="px-3 py-1 text-sm bg-blue-100 text-blue-800 rounded hover:bg-blue-200"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {directories.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          No projects found with session data.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {directories.map((dir) => (
+            <div
+              key={dir.project_path}
+              className="border border-gray-200 rounded-lg overflow-hidden"
+            >
+              <div
+                className="p-4 bg-gray-50 cursor-pointer hover:bg-gray-100 transition-colors"
+                onClick={() => toggleProject(dir.project_path)}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <span className="text-lg">
+                      {expandedProjects.has(dir.project_path) ? "📂" : "📁"}
+                    </span>
+                    <div>
+                      <h3 className="font-medium text-gray-900">
+                        {dir.project_path}
+                      </h3>
+                      <div className="flex items-center space-x-4 text-sm text-gray-500 mt-1">
+                        <span
+                          className={`px-2 py-1 rounded-full text-xs ${
+                            dir.exists
+                              ? "bg-green-100 text-green-800"
+                              : "bg-gray-100 text-gray-600"
+                          }`}
+                        >
+                          {dir.exists
+                            ? ".claude directory exists"
+                            : "No .claude directory"}
+                        </span>
+                        {dir.commands_dir && (
+                          <span className="bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-xs">
+                            {dir.commands_dir.commands.length} commands
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="text-gray-400">
+                    {expandedProjects.has(dir.project_path) ? "▼" : "▶"}
+                  </div>
+                </div>
+              </div>
+
+              {expandedProjects.has(dir.project_path) && (
+                <div className="p-4 border-t border-gray-200 bg-white">
+                  {!dir.exists ? (
+                    <p className="text-gray-500 italic">
+                      This project does not have a .claude directory.
+                    </p>
+                  ) : (
+                    <div className="space-y-4">
+                      <div>
+                        <h4 className="font-medium text-gray-700 mb-1">
+                          Directory Path
+                        </h4>
+                        <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                          {dir.claude_dir_path}
+                        </code>
+                      </div>
+
+                      {dir.commands_dir &&
+                        dir.commands_dir.commands.length > 0 && (
+                          <div>
+                            <h4 className="font-medium text-gray-700 mb-2">
+                              Commands
+                            </h4>
+                            <div className="space-y-2">
+                              {dir.commands_dir.commands.map((cmd, index) => (
+                                <div
+                                  key={index}
+                                  className="border border-gray-200 rounded p-3"
+                                >
+                                  <div className="flex items-center justify-between mb-2">
+                                    <h5 className="font-medium text-gray-800">
+                                      {cmd.name}
+                                    </h5>
+                                    <code className="text-xs bg-gray-100 px-2 py-1 rounded">
+                                      {cmd.path}
+                                    </code>
+                                  </div>
+                                  <div className="bg-gray-50 p-3 rounded text-sm">
+                                    <pre className="whitespace-pre-wrap text-gray-700">
+                                      {cmd.content}
+                                    </pre>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
+                      {dir.settings_local && (
+                        <div>
+                          <h4 className="font-medium text-gray-700 mb-2">
+                            Local Settings (settings.local.json)
+                          </h4>
+                          <div className="bg-gray-50 p-3 rounded text-sm font-mono">
+                            {renderJsonValue(dir.settings_local)}
+                          </div>
+                        </div>
+                      )}
+
+                      {dir.settings && (
+                        <div>
+                          <h4 className="font-medium text-gray-700 mb-2">
+                            Settings (settings.json)
+                          </h4>
+                          <div className="bg-gray-50 p-3 rounded text-sm font-mono">
+                            {renderJsonValue(dir.settings)}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectClaudeDirectories;

--- a/src/tests/ProjectClaudeDirectories.test.tsx
+++ b/src/tests/ProjectClaudeDirectories.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import ProjectClaudeDirectories from "../components/ProjectClaudeDirectories";
+import * as api from "../api";
+
+// Mock the API
+vi.mock("../api", () => ({
+  api: {
+    getProjectClaudeDirectories: vi.fn(),
+  },
+}));
+
+const mockApi = api.api as any;
+
+describe("ProjectClaudeDirectories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    mockApi.getProjectClaudeDirectories.mockReturnValue(new Promise(() => {}));
+
+    render(<ProjectClaudeDirectories />);
+    expect(
+      screen.getByText("Loading project .claude directories..."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders error state when API call fails", async () => {
+    const errorMessage = "Failed to load directories";
+    mockApi.getProjectClaudeDirectories.mockRejectedValue(
+      new Error(errorMessage),
+    );
+
+    render(<ProjectClaudeDirectories />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Error loading directories")).toBeInTheDocument();
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+  });
+
+  it("renders empty state when no projects found", async () => {
+    mockApi.getProjectClaudeDirectories.mockResolvedValue([]);
+
+    render(<ProjectClaudeDirectories />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No projects found with session data."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders project directories with basic information", async () => {
+    const mockDirectories = [
+      {
+        project_path: "/Users/developer/projects/web-app",
+        claude_dir_path: "/Users/developer/projects/web-app/.claude",
+        exists: true,
+        commands_dir: {
+          path: "/Users/developer/projects/web-app/.claude/commands",
+          commands: [
+            {
+              name: "build.md",
+              path: "/Users/developer/projects/web-app/.claude/commands/build.md",
+              content: "# Build Command\n\nnpm run build",
+            },
+          ],
+        },
+        settings_local: {
+          permissions: {
+            defaultMode: "accept",
+          },
+        },
+      },
+      {
+        project_path: "/Users/developer/projects/api-server",
+        claude_dir_path: "/Users/developer/projects/api-server/.claude",
+        exists: false,
+      },
+    ];
+
+    mockApi.getProjectClaudeDirectories.mockResolvedValue(mockDirectories);
+
+    render(<ProjectClaudeDirectories />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Project .claude Directories"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("/Users/developer/projects/web-app"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("/Users/developer/projects/api-server"),
+      ).toBeInTheDocument();
+      expect(screen.getByText(".claude directory exists")).toBeInTheDocument();
+      expect(screen.getByText("No .claude directory")).toBeInTheDocument();
+      expect(screen.getByText("1 commands")).toBeInTheDocument();
+    });
+  });
+
+  it("expands and collapses project details when clicked", async () => {
+    const mockDirectories = [
+      {
+        project_path: "/Users/developer/projects/web-app",
+        claude_dir_path: "/Users/developer/projects/web-app/.claude",
+        exists: true,
+        commands_dir: {
+          path: "/Users/developer/projects/web-app/.claude/commands",
+          commands: [
+            {
+              name: "build.md",
+              path: "/Users/developer/projects/web-app/.claude/commands/build.md",
+              content: "# Build Command\n\nnpm run build",
+            },
+          ],
+        },
+        settings_local: {
+          permissions: {
+            defaultMode: "accept",
+          },
+        },
+      },
+    ];
+
+    mockApi.getProjectClaudeDirectories.mockResolvedValue(mockDirectories);
+
+    render(<ProjectClaudeDirectories />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("/Users/developer/projects/web-app"),
+      ).toBeInTheDocument();
+    });
+
+    // Initially collapsed, should not show details
+    expect(screen.queryByText("Directory Path")).not.toBeInTheDocument();
+    expect(screen.queryByText("Commands")).not.toBeInTheDocument();
+
+    // Click to expand
+    const projectHeader = screen
+      .getByText("/Users/developer/projects/web-app")
+      .closest("div");
+    if (projectHeader?.parentElement) {
+      fireEvent.click(projectHeader.parentElement);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText("Directory Path")).toBeInTheDocument();
+      expect(screen.getByText("Commands")).toBeInTheDocument();
+      expect(screen.getByText("build.md")).toBeInTheDocument();
+      expect(
+        screen.getByText((content, element) =>
+          content.includes("# Build Command"),
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Local Settings (settings.local.json)"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows message for projects without .claude directory", async () => {
+    const mockDirectories = [
+      {
+        project_path: "/Users/developer/projects/api-server",
+        claude_dir_path: "/Users/developer/projects/api-server/.claude",
+        exists: false,
+      },
+    ];
+
+    mockApi.getProjectClaudeDirectories.mockResolvedValue(mockDirectories);
+
+    render(<ProjectClaudeDirectories />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("/Users/developer/projects/api-server"),
+      ).toBeInTheDocument();
+    });
+
+    // Click to expand
+    const projectHeader = screen
+      .getByText("/Users/developer/projects/api-server")
+      .closest("div");
+    if (projectHeader?.parentElement) {
+      fireEvent.click(projectHeader.parentElement);
+    }
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("This project does not have a .claude directory."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("handles refresh functionality", async () => {
+    mockApi.getProjectClaudeDirectories.mockResolvedValue([]);
+
+    render(<ProjectClaudeDirectories />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No projects found with session data."),
+      ).toBeInTheDocument();
+    });
+
+    // Reset mock to return data on refresh
+    const mockDirectories = [
+      {
+        project_path: "/Users/developer/projects/web-app",
+        claude_dir_path: "/Users/developer/projects/web-app/.claude",
+        exists: true,
+      },
+    ];
+    mockApi.getProjectClaudeDirectories.mockResolvedValue(mockDirectories);
+
+    // Click refresh button
+    const refreshButton = screen.getByText("Refresh");
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("/Users/developer/projects/web-app"),
+      ).toBeInTheDocument();
+    });
+
+    // Verify API was called twice (initial load + refresh)
+    expect(mockApi.getProjectClaudeDirectories).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,3 +113,31 @@ export interface SessionStats {
   active_projects: number;
   pending_todos: number;
 }
+
+export interface ClaudeProjectInfo {
+  project_path: string;
+  has_claude_dir: boolean;
+  commands: string[];
+  settings_local?: any;
+  settings?: any;
+}
+
+export interface ProjectClaudeDirectory {
+  project_path: string;
+  claude_dir_path: string;
+  exists: boolean;
+  commands_dir?: CommandsDirectory;
+  settings_local?: any;
+  settings?: any;
+}
+
+export interface CommandsDirectory {
+  path: string;
+  commands: CommandFile[];
+}
+
+export interface CommandFile {
+  name: string;
+  path: string;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- 各プロジェクトの.claudeディレクトリの存在確認と内容表示機能を実装
- commandsディレクトリ内のMarkdownファイルの内容を表示
- settings.local.json と settings.json の内容をJSON形式で表示
- 新しいUIタブ「.claude Dirs」を追加してアクセス可能

## Technical Changes
- Rustバックエンド: `get_project_claude_directories` コマンドを追加
- 新しいデータ構造: `ProjectClaudeDirectory`, `CommandsDirectory`, `CommandFile`
- Reactフロントエンド: `ProjectClaudeDirectories` コンポーネントを新規作成
- 完全なテストカバレッジ (React + Rust)

## Test plan
- ✅ React component tests (7 tests)
- ✅ Rust unit tests (3 new tests)
- ✅ TypeScript type checking
- ✅ Rust clippy linting
- ✅ All existing tests passing

close #35

🤖 Generated with [Claude Code](https://claude.ai/code)