### PR TITLE
👷 Fix CI not triggering on dependency update PRs

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -38,4 +38,6 @@ jobs:
           allowed_tools: "Bash,Read,Write,Edit,Glob,Grep,TodoWrite"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Personal Access Tokenを使用してPRを作成（CIワークフローをトリガーするため）
+          # GITHUB_TOKENの代わりにPATを使用することで、作成されたPRがCIをトリガーできます
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixed GitHub Actions CI workflow not triggering when PRs are created by the update-dependencies workflow. Added support for Personal Access Token (PAT) to enable proper workflow triggering.

## Problem
- PRs created by update-dependencies workflow using GITHUB_TOKEN were not triggering CI checks
- This is a security limitation in GitHub Actions to prevent infinite loops
- Documentation: Events triggered by GITHUB_TOKEN will not create new workflow runs

## Solution
- Modified `.github/workflows/update-dependencies.yml` to support PAT
- Added fallback to GITHUB_TOKEN if PAT is not configured
- Added Japanese comments explaining the purpose

## Setup Required
To enable CI triggers on dependency update PRs:
1. Create a Personal Access Token with `repo` and `workflow` permissions
2. Add it as `GH_PAT` in repository secrets
3. If not configured, falls back to GITHUB_TOKEN (but CI won't trigger)

## Test plan
- [ ] Verify workflow runs successfully with PAT configured
- [ ] Verify fallback to GITHUB_TOKEN works when PAT is not set
- [ ] Confirm CI workflows trigger on PRs created with PAT

🤖 Generated with [Claude Code](https://claude.ai/code)