### PR TITLE
Update typescript to v5.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "jsdom": "^23.0.0",
-        "typescript": "~5.6.2",
+        "typescript": "^5.9.2",
         "vite": "^6.0.3",
         "vitest": "^3.2.4"
       }
@@ -3888,10 +3888,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "jsdom": "^23.0.0",
-    "typescript": "~5.6.2",
+    "typescript": "^5.9.2",
     "vite": "^6.0.3",
     "vitest": "^3.2.4"
   }


### PR DESCRIPTION
## Summary
- Upgrade typescript from ~5.6.2 to ^5.9.2

## Test plan
- [x] All frontend tests pass successfully
- [x] TypeScript checks pass
- [x] Package dependencies updated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)