### PR TITLE
Update dependency workflow and package versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -35,6 +35,7 @@ jobs:
             package-lock.jsonだけを更新するのではなく、package.jsonのdependenciesとdevDependenciesを更新してください。
             もし、アップデートが必要なdependencyがない場合は、その旨を報告してください。
             もし、他のCIのjobが失敗した場合には、そのjobをチェックし修正してください。
+            すでに同じ差分のPRがあれば、新しいPRを作成しないでください。
           allowed_tools: "Bash,Read,Write,Edit,Glob,Grep,TodoWrite"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         env:


### PR DESCRIPTION
## Summary
- Add check to prevent duplicate PRs in the update-dependencies workflow
- Update package.json to use more flexible version ranges for @tauri-apps packages
- Downgrade jsdom from v26 to v23 for better compatibility

## Changes
- **GitHub Workflow**: Added a check to prevent creating duplicate pull requests with the same changes
- **Package Dependencies**: 
  - Changed `@tauri-apps/api` and `@tauri-apps/cli` to use caret version ranges (`^2`)
  - Downgraded `jsdom` from `^26.1.0` to `^23.0.0`

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Run `npm install` to ensure dependencies install correctly
- [ ] Run `npm run tauri:dev` to verify the application builds and runs
- [ ] Check that no duplicate PRs are created when the workflow runs

🤖 Generated with [Claude Code](https://claude.ai/code)