### PR TITLE
Update @types/node to version 24.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.0.0",
-        "@types/node": "^24.3.1",
+        "@types/node": "^24.3.3",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
@@ -1866,9 +1866,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
-      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "version": "24.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.3.tgz",
+      "integrity": "sha512-GKBNHjoNw3Kra1Qg5UXttsY5kiWMEfoHq2TmXb+b1rcm6N7B3wTrFYIf/oSZ1xNQ+hVVijgLkiDZh7jRRsh+Gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.0.0",
-    "@types/node": "^24.3.1",
+    "@types/node": "^24.3.3",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",


### PR DESCRIPTION
## Summary
- Update @types/node from version ^24.3.1 to ^24.3.3
- This is a patch version update with bug fixes and improvements
- No breaking changes in this patch version update

## Test plan
- [x] TypeScript type checking passes without errors
- [x] All tests pass (71 passed, 10 skipped) 
- [x] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)