### PR TITLE
Update @types/react to version 19.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.0.0",
         "@types/node": "^24.3.1",
-        "@types/react": "^19.1.12",
+        "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
         "@vitest/coverage-v8": "^3.2.4",
@@ -1876,9 +1876,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.0.0",
     "@types/node": "^24.3.1",
-    "@types/react": "^19.1.12",
+    "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
     "@vitest/coverage-v8": "^3.2.4",


### PR DESCRIPTION
## Summary
- Update @types/react from version ^19.1.12 to ^19.1.13
- This is a patch version update for React 19 type definitions  
- Includes latest type fixes and improvements
- No breaking changes in this patch version update

## Test plan
- [x] TypeScript type checking passes without errors
- [x] All tests pass (71 passed, 10 skipped)
- [x] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)