### PR TITLE
Claude Code Manager 内からプロンプトを書いて指示できるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,13 +74,13 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -99,22 +99,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
-      "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.3",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -130,14 +130,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -147,14 +147,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -174,29 +174,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -236,9 +236,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -246,27 +246,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
-      "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.2"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -318,33 +318,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.3.tgz",
-      "integrity": "sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.3",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.2",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -352,14 +352,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -649,9 +649,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -666,9 +666,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -683,9 +683,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -700,9 +700,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -717,9 +717,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -734,9 +734,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -768,9 +768,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -802,9 +802,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -819,9 +819,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -836,9 +836,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -853,9 +853,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -870,9 +870,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -887,9 +887,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -904,9 +904,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -938,9 +938,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -955,9 +955,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -972,9 +972,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -989,9 +989,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1023,9 +1023,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -1040,9 +1040,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -1057,9 +1057,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -1074,9 +1074,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -1129,6 +1129,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -1157,6 +1168,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1183,9 +1211,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.49.0.tgz",
-      "integrity": "sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
@@ -1197,9 +1225,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.49.0.tgz",
-      "integrity": "sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
@@ -1211,9 +1239,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.49.0.tgz",
-      "integrity": "sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
@@ -1225,9 +1253,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.49.0.tgz",
-      "integrity": "sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
@@ -1239,9 +1267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.49.0.tgz",
-      "integrity": "sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
@@ -1253,9 +1281,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.49.0.tgz",
-      "integrity": "sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
@@ -1267,9 +1295,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.49.0.tgz",
-      "integrity": "sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
@@ -1281,9 +1309,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.49.0.tgz",
-      "integrity": "sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
@@ -1295,9 +1323,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.49.0.tgz",
-      "integrity": "sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
@@ -1309,9 +1337,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.49.0.tgz",
-      "integrity": "sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
@@ -1322,10 +1350,24 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.49.0.tgz",
-      "integrity": "sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
       "cpu": [
         "loong64"
       ],
@@ -1337,9 +1379,23 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.49.0.tgz",
-      "integrity": "sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
       "cpu": [
         "ppc64"
       ],
@@ -1351,9 +1407,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.49.0.tgz",
-      "integrity": "sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1365,9 +1421,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.49.0.tgz",
-      "integrity": "sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
@@ -1379,9 +1435,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.49.0.tgz",
-      "integrity": "sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
@@ -1393,9 +1449,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.49.0.tgz",
-      "integrity": "sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
@@ -1407,9 +1463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.49.0.tgz",
-      "integrity": "sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
       ],
@@ -1420,10 +1476,38 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.49.0.tgz",
-      "integrity": "sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
@@ -1435,9 +1519,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.49.0.tgz",
-      "integrity": "sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
@@ -1448,10 +1532,24 @@
         "win32"
       ]
     },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.49.0.tgz",
-      "integrity": "sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
@@ -1842,13 +1940,14 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1859,9 +1958,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1924,9 +2023,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1948,8 +2047,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1958,15 +2057,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1975,13 +2074,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2002,9 +2101,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2015,13 +2114,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2030,13 +2129,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2045,9 +2144,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2058,13 +2157,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
-      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.7.tgz",
+      "integrity": "sha512-eVtcpJXGhS0GjMuHROfbXLhlxooyUcuip8GNzzjDD5jzafZqzanJH4W3VGmUxHNx4fv6qQGUGJHRpGUdj+9D6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -2076,17 +2175,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.4"
+        "vitest": "3.2.7"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -2173,10 +2272,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2184,9 +2296,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
-      "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2204,10 +2316,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001737",
-        "electron-to-chromium": "^1.5.211",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2227,9 +2340,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -2265,9 +2378,9 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2408,9 +2521,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2424,9 +2537,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.211",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
-      "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2457,9 +2570,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2470,32 +2583,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.9",
-        "@esbuild/android-arm": "0.25.9",
-        "@esbuild/android-arm64": "0.25.9",
-        "@esbuild/android-x64": "0.25.9",
-        "@esbuild/darwin-arm64": "0.25.9",
-        "@esbuild/darwin-x64": "0.25.9",
-        "@esbuild/freebsd-arm64": "0.25.9",
-        "@esbuild/freebsd-x64": "0.25.9",
-        "@esbuild/linux-arm": "0.25.9",
-        "@esbuild/linux-arm64": "0.25.9",
-        "@esbuild/linux-ia32": "0.25.9",
-        "@esbuild/linux-loong64": "0.25.9",
-        "@esbuild/linux-mips64el": "0.25.9",
-        "@esbuild/linux-ppc64": "0.25.9",
-        "@esbuild/linux-riscv64": "0.25.9",
-        "@esbuild/linux-s390x": "0.25.9",
-        "@esbuild/linux-x64": "0.25.9",
-        "@esbuild/netbsd-arm64": "0.25.9",
-        "@esbuild/netbsd-x64": "0.25.9",
-        "@esbuild/openbsd-arm64": "0.25.9",
-        "@esbuild/openbsd-x64": "0.25.9",
-        "@esbuild/openharmony-arm64": "0.25.9",
-        "@esbuild/sunos-x64": "0.25.9",
-        "@esbuild/win32-arm64": "0.25.9",
-        "@esbuild/win32-ia32": "0.25.9",
-        "@esbuild/win32-x64": "0.25.9"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/escalade": {
@@ -2554,9 +2667,9 @@
       "license": "MIT"
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2603,9 +2716,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2980,13 +3094,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3022,9 +3136,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3041,11 +3155,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.21",
@@ -3131,9 +3248,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3144,9 +3261,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3164,7 +3281,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3251,13 +3368,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
-      "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3267,26 +3384,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.49.0",
-        "@rollup/rollup-android-arm64": "4.49.0",
-        "@rollup/rollup-darwin-arm64": "4.49.0",
-        "@rollup/rollup-darwin-x64": "4.49.0",
-        "@rollup/rollup-freebsd-arm64": "4.49.0",
-        "@rollup/rollup-freebsd-x64": "4.49.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.49.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.49.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.49.0",
-        "@rollup/rollup-linux-arm64-musl": "4.49.0",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.49.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.49.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.49.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-gnu": "4.49.0",
-        "@rollup/rollup-linux-x64-musl": "4.49.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.49.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.49.0",
-        "@rollup/rollup-win32-x64-msvc": "4.49.0",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -3523,9 +3646,9 @@
       }
     },
     "node_modules/strip-literal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3591,14 +3714,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3628,9 +3751,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3711,9 +3834,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {
@@ -3742,18 +3865,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.3.tgz",
-      "integrity": "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
         "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.14"
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3840,20 +3963,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -3883,8 +4006,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -4102,9 +4225,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -516,6 +516,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
+ "libc",
  "notify",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -373,9 +373,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2249,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -2795,9 +2795,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.11.0",
@@ -2932,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3291,10 +3291,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3310,14 +3311,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3632,6 +3642,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4048,30 +4069,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,10 @@ dirs = "5.0"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 
+# プロセスグループ単位でのシグナル送信（プロンプト実行の停止）に使用
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3.0"
 tokio-test = "0.4"

--- a/src-tauri/src/claude_data.rs
+++ b/src-tauri/src/claude_data.rs
@@ -175,7 +175,7 @@ impl ClaudeDataManager {
             }
         }
 
-        sessions.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
         Ok(sessions)
     }
 
@@ -594,7 +594,7 @@ impl ClaudeDataManager {
             }
         }
 
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
         Ok(entries)
     }
 
@@ -729,7 +729,7 @@ impl ClaudeDataManager {
 
         let mut projects: Vec<ProjectSummary> = project_map.into_values().collect();
         // Sort by last_activity in descending order (most recent first)
-        projects.sort_by(|a, b| b.last_activity.cmp(&a.last_activity));
+        projects.sort_by_key(|p| std::cmp::Reverse(p.last_activity));
         Ok(projects)
     }
 
@@ -816,7 +816,7 @@ impl ClaudeDataManager {
             }
         }
 
-        changed_sessions.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        changed_sessions.sort_by_key(|s| std::cmp::Reverse(s.timestamp));
         Ok(changed_sessions)
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,8 +1,9 @@
 use crate::claude_data::ClaudeDataManager;
 use crate::models::*;
+use crate::prompt_runner::{PromptRunner, StartPromptRunRequest};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 #[tauri::command]
 pub async fn get_all_sessions(
@@ -407,4 +408,59 @@ pub async fn save_settings_file(
         .save_settings_file(&filename, &content)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// `claude` CLI が利用可能かを返す。
+///
+/// 検出に失敗しても `Err` にはせず `available: false` を返し、
+/// フロントエンドが警告バナーを表示できるようにする。
+#[tauri::command]
+pub async fn get_claude_cli_status() -> Result<ClaudeCliStatus, String> {
+    Ok(crate::prompt_runner::claude_cli_status().await)
+}
+
+/// プロンプトを Claude Code CLI に投げ、実行 ID（UUID v4）を返す。
+///
+/// 進捗は `prompt-run-event` イベントで配信される。
+#[tauri::command]
+pub async fn start_prompt_run(
+    project_path: String,
+    prompt: String,
+    permission_mode: PermissionMode,
+    resume_session_id: Option<String>,
+    model: Option<String>,
+    app: AppHandle,
+    prompt_runner: State<'_, Arc<PromptRunner>>,
+) -> Result<String, String> {
+    let runner = Arc::clone(prompt_runner.inner());
+    runner
+        .start(
+            app,
+            StartPromptRunRequest {
+                project_path,
+                prompt,
+                permission_mode,
+                // 空文字は「未指定」として扱う（UI の空入力を許容する）
+                resume_session_id: normalize_optional_arg(resume_session_id),
+                model: normalize_optional_arg(model),
+            },
+        )
+        .await
+}
+
+/// 実行中のプロンプトを停止する。
+#[tauri::command]
+pub async fn stop_prompt_run(
+    run_id: String,
+    prompt_runner: State<'_, Arc<PromptRunner>>,
+) -> Result<(), String> {
+    let runner = Arc::clone(prompt_runner.inner());
+    runner.stop(&run_id).await
+}
+
+/// 空白のみ・空文字の任意引数を `None` に正規化する。
+fn normalize_optional_arg(value: Option<String>) -> Option<String> {
+    value
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,11 +3,13 @@ use std::sync::Arc;
 mod claude_data;
 mod commands;
 mod models;
+mod prompt_runner;
 #[cfg(test)]
 mod tests;
 
 use claude_data::ClaudeDataManager;
 use commands::*;
+use prompt_runner::PromptRunner;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -17,6 +19,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .manage(data_manager)
+        .manage(Arc::new(PromptRunner::new()))
         .invoke_handler(tauri::generate_handler![
             get_all_sessions,
             get_changed_sessions,
@@ -46,7 +49,10 @@ pub fn run() {
             rename_custom_command,
             rename_agent,
             get_all_settings_files,
-            save_settings_file
+            save_settings_file,
+            get_claude_cli_status,
+            start_prompt_run,
+            stop_prompt_run
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -222,3 +222,68 @@ pub struct Agent {
     pub name: String,
     pub content: String,
 }
+
+/// Claude Code CLI の `--permission-mode` に渡す権限モード。
+///
+/// JSON 表現は CLI 引数と同一文字列（camelCase）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PermissionMode {
+    #[serde(rename = "plan")]
+    Plan,
+    #[serde(rename = "acceptEdits")]
+    AcceptEdits,
+    #[serde(rename = "bypassPermissions")]
+    BypassPermissions,
+}
+
+impl PermissionMode {
+    /// `--permission-mode` に渡す文字列表現を返す。
+    pub fn as_cli_arg(&self) -> &'static str {
+        match self {
+            Self::Plan => "plan",
+            Self::AcceptEdits => "acceptEdits",
+            Self::BypassPermissions => "bypassPermissions",
+        }
+    }
+}
+
+/// `claude` CLI の検出結果。UI の警告バナー表示に使う。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaudeCliStatus {
+    pub available: bool,
+    /// 解決された `claude` バイナリの絶対パス。
+    pub path: Option<String>,
+    /// `claude --version` の出力（トリム済み）。
+    pub version: Option<String>,
+    /// `available` が false のときの理由。
+    pub error: Option<String>,
+}
+
+/// プロンプト実行中にフロントエンドへ通知するイベント種別。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptRunEventKind {
+    /// stream-json の 1 行をパースしたもの。
+    Message,
+    /// 標準エラー出力、または JSON として解釈できなかった行。
+    Stderr,
+    /// プロセス終了（各実行につき最後に必ず 1 回だけ流れる）。
+    Exit,
+    /// 実行制御自体のエラー。
+    Error,
+}
+
+/// `prompt-run-event` のペイロード。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptRunEvent {
+    pub run_id: String,
+    pub kind: PromptRunEventKind,
+    /// `kind = Message` のときの stream-json オブジェクト。
+    pub payload: Option<serde_json::Value>,
+    /// `kind = Stderr` / `Error` のときのテキスト。
+    pub text: Option<String>,
+    /// `kind = Exit` のときの終了コード。
+    pub exit_code: Option<i32>,
+    /// `kind = Exit` のときの成否（停止された場合は false）。
+    pub success: Option<bool>,
+}

--- a/src-tauri/src/prompt_runner.rs
+++ b/src-tauri/src/prompt_runner.rs
@@ -1,0 +1,726 @@
+//! Claude Code CLI をヘッドレスモード（`-p --output-format stream-json`）で起動し、
+//! 標準出力の stream-json を Tauri イベントとしてフロントエンドへ中継するモジュール。
+//!
+//! 設計上のポイント:
+//! - GUI アプリは Finder から起動されると PATH が最小限になるため、CLI の場所を多段で解決する
+//! - プロンプトは argv ではなく stdin へ渡す（クォート事故・引数インジェクション回避）
+//! - CLI へ渡す `--resume` / `--model` の値は厳格にバリデーションする
+//! - 停止時はプロセスグループごとシグナルを送り、子孫プロセスを残さない
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+use std::time::Duration;
+
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout, Command};
+use uuid::Uuid;
+
+use crate::models::{ClaudeCliStatus, PermissionMode, PromptRunEvent, PromptRunEventKind};
+
+/// フロントエンドが購読する Tauri イベント名（API 契約で固定）。
+pub const PROMPT_RUN_EVENT: &str = "prompt-run-event";
+
+/// `--resume` に渡すセッション ID の最大長。
+const MAX_SESSION_ID_LEN: usize = 64;
+/// `--model` に渡すモデル名の最大長。
+const MAX_MODEL_LEN: usize = 64;
+/// ログインシェルや `claude --version` など補助プロセスのタイムアウト。
+const HELPER_PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
+/// SIGTERM 後に終了を待つポーリング間隔。
+const STOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// SIGKILL へ切り替えるまでのポーリング回数（100ms × 20 = 2 秒）。
+const STOP_POLL_ATTEMPTS: u32 = 20;
+
+// ---------------------------------------------------------------------------
+// CLI バイナリ解決
+// ---------------------------------------------------------------------------
+
+/// `claude` バイナリの絶対パスを解決する。
+///
+/// 解決順:
+/// 1. 環境変数 `CLAUDE_CLI_PATH`（明示指定を最優先）
+/// 2. ログインシェル経由の `command -v claude`（unix のみ）
+/// 3. 既知のインストール先候補
+/// 4. 現在のプロセスの `PATH`
+///
+/// 内部でファイル存在確認と補助プロセス起動を行うためブロッキングする。
+/// 非同期コンテキストからは [`resolve_cli_environment`] 経由で呼ぶこと。
+pub fn resolve_claude_binary() -> Result<PathBuf, String> {
+    // 解決にはログインシェルの起動が伴い数百 ms かかることがある。
+    // プロンプト送信のたびに払うコストではないため、成功結果だけキャッシュする
+    // （失敗をキャッシュすると、CLI を後から入れたときに再起動が必須になる）。
+    static CACHED_BINARY: OnceLock<PathBuf> = OnceLock::new();
+    if let Some(cached) = CACHED_BINARY.get() {
+        if cached.is_file() {
+            return Ok(cached.clone());
+        }
+    }
+
+    let resolved = resolve_claude_binary_uncached()?;
+    let _ = CACHED_BINARY.set(resolved.clone());
+    Ok(resolved)
+}
+
+/// キャッシュを介さずに `claude` バイナリを探索する。
+fn resolve_claude_binary_uncached() -> Result<PathBuf, String> {
+    if let Some(path) = binary_from_env_var() {
+        return Ok(path);
+    }
+
+    #[cfg(unix)]
+    if let Some(path) = binary_from_login_shell() {
+        return Ok(path);
+    }
+
+    if let Some(path) = known_install_candidates().into_iter().find(|p| p.is_file()) {
+        return Ok(path);
+    }
+
+    if let Some(path) = binary_from_path_env() {
+        return Ok(path);
+    }
+
+    Err(concat!(
+        "Claude Code CLI (`claude`) が見つかりませんでした。",
+        "インストール済みか確認するか、環境変数 CLAUDE_CLI_PATH に ",
+        "`claude` の絶対パスを設定してからアプリを再起動してください。"
+    )
+    .to_string())
+}
+
+/// 環境変数 `CLAUDE_CLI_PATH` で明示指定されたパスを取得する。
+fn binary_from_env_var() -> Option<PathBuf> {
+    let raw = std::env::var_os("CLAUDE_CLI_PATH")?;
+    let path = PathBuf::from(raw);
+    path.is_file().then_some(path)
+}
+
+/// 既知のインストール先候補（存在チェックは呼び出し側）。
+fn known_install_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::with_capacity(5);
+
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".local").join("bin").join("claude"));
+        candidates.push(home.join(".claude").join("local").join("claude"));
+    }
+    candidates.push(PathBuf::from("/opt/homebrew/bin/claude"));
+    candidates.push(PathBuf::from("/usr/local/bin/claude"));
+    candidates.push(PathBuf::from("/usr/bin/claude"));
+
+    candidates
+}
+
+/// 現在のプロセスの `PATH` を走査して `claude` を探す。
+fn binary_from_path_env() -> Option<PathBuf> {
+    // Windows では拡張子付きの実体を優先して探す。
+    let file_names: &[&str] = if cfg!(windows) {
+        &["claude.cmd", "claude.exe", "claude"]
+    } else {
+        &["claude"]
+    };
+
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var).find_map(|dir| {
+        file_names
+            .iter()
+            .map(|name| dir.join(name))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
+/// ログインシェル経由で `claude` の場所を解決する。
+#[cfg(unix)]
+fn binary_from_login_shell() -> Option<PathBuf> {
+    let stdout = run_login_shell("command -v claude")?;
+    let first_line = stdout.lines().next()?.trim();
+    if first_line.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(first_line);
+    path.is_file().then_some(path)
+}
+
+/// ログインシェルの `PATH`（プロセス内キャッシュ）。
+///
+/// `claude` は node を必要とするため、子プロセスにはログインシェル相当の
+/// `PATH` を渡す。取得できない場合は `None`（現在の `PATH` をそのまま使う）。
+pub fn login_shell_path() -> Option<String> {
+    static LOGIN_SHELL_PATH: OnceLock<Option<String>> = OnceLock::new();
+    LOGIN_SHELL_PATH
+        .get_or_init(detect_login_shell_path)
+        .clone()
+}
+
+#[cfg(unix)]
+fn detect_login_shell_path() -> Option<String> {
+    let stdout = run_login_shell("echo $PATH")?;
+    let path = stdout.lines().next()?.trim().to_string();
+    (!path.is_empty()).then_some(path)
+}
+
+#[cfg(not(unix))]
+fn detect_login_shell_path() -> Option<String> {
+    None
+}
+
+/// `$SHELL -lc <script>` を実行し、標準出力を返す。
+///
+/// ログインシェルの初期化スクリプトが固まるケースに備えてタイムアウトを設け、
+/// 超過したら子プロセスを kill して `None` を返す（アプリを巻き込まない）。
+#[cfg(unix)]
+fn run_login_shell(script: &str) -> Option<String> {
+    let shell = std::env::var("SHELL").ok().filter(|s| !s.is_empty())?;
+
+    let mut child = std::process::Command::new(shell)
+        .arg("-lc")
+        .arg(script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = std::time::Instant::now() + HELPER_PROCESS_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            // タイムアウト、または待機自体の失敗
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+
+    let output = child.wait_with_output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// ブロッキング処理（バイナリ探索とログインシェル起動）をまとめて実行する。
+///
+/// 非同期コマンドからは `tokio::task::spawn_blocking` 経由で呼び出す。
+fn resolve_cli_environment() -> Result<(PathBuf, Option<String>), String> {
+    let binary = resolve_claude_binary()?;
+    Ok((binary, login_shell_path()))
+}
+
+/// `spawn_blocking` で CLI 環境を解決する非同期ラッパー。
+async fn resolve_cli_environment_async() -> Result<(PathBuf, Option<String>), String> {
+    tokio::task::spawn_blocking(resolve_cli_environment)
+        .await
+        .map_err(|e| format!("CLI パスの解決に失敗しました: {e}"))?
+}
+
+// ---------------------------------------------------------------------------
+// CLI 引数の組み立て
+// ---------------------------------------------------------------------------
+
+/// `claude` に渡す引数列を組み立てる（副作用のない純粋関数）。
+///
+/// `resume_session_id` / `model` は引数インジェクションを防ぐため、
+/// 長さ・文字種・先頭ハイフンを検証する。
+pub fn build_claude_args(
+    permission_mode: PermissionMode,
+    resume_session_id: Option<&str>,
+    model: Option<&str>,
+) -> Result<Vec<String>, String> {
+    let mut args = vec![
+        "-p".to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+        "--permission-mode".to_string(),
+        permission_mode.as_cli_arg().to_string(),
+    ];
+
+    if let Some(session_id) = resume_session_id {
+        validate_cli_value(
+            session_id,
+            MAX_SESSION_ID_LEN,
+            is_session_id_char,
+            "セッション ID",
+        )?;
+        args.push("--resume".to_string());
+        args.push(session_id.to_string());
+    }
+
+    if let Some(model) = model {
+        validate_cli_value(model, MAX_MODEL_LEN, is_model_char, "モデル名")?;
+        args.push("--model".to_string());
+        args.push(model.to_string());
+    }
+
+    Ok(args)
+}
+
+/// CLI に渡す値の安全性を検証する。
+fn validate_cli_value(
+    value: &str,
+    max_len: usize,
+    is_allowed_char: fn(char) -> bool,
+    label: &str,
+) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("{label}が空です。"));
+    }
+    if value.len() > max_len {
+        return Err(format!("{label}が長すぎます（最大 {max_len} 文字）。"));
+    }
+    // 先頭がハイフンだと別のオプションとして解釈されうるため拒否する。
+    if value.starts_with('-') {
+        return Err(format!("{label}をハイフンで始めることはできません。"));
+    }
+    if !value.chars().all(is_allowed_char) {
+        return Err(format!("{label}に使用できない文字が含まれています。"));
+    }
+    Ok(())
+}
+
+/// セッション ID に許可する文字（`[A-Za-z0-9_-]`）。
+fn is_session_id_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '_' | '-')
+}
+
+/// モデル名に許可する文字（`[A-Za-z0-9._-]`）。
+fn is_model_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')
+}
+
+// ---------------------------------------------------------------------------
+// CLI の状態取得
+// ---------------------------------------------------------------------------
+
+/// `claude` CLI の利用可否を調べる。解決に失敗しても `Err` にはせず、
+/// UI が警告バナーを出せるよう `available: false` を返す。
+pub async fn claude_cli_status() -> ClaudeCliStatus {
+    match resolve_cli_environment_async().await {
+        Ok((binary, path_env)) => {
+            let version = claude_version(&binary, path_env.as_deref()).await;
+            ClaudeCliStatus {
+                available: true,
+                path: Some(binary.to_string_lossy().into_owned()),
+                version,
+                error: None,
+            }
+        }
+        Err(error) => ClaudeCliStatus {
+            available: false,
+            path: None,
+            version: None,
+            error: Some(error),
+        },
+    }
+}
+
+/// `claude --version` の出力（トリム済み）を取得する。失敗時は `None`。
+async fn claude_version(binary: &Path, path_env: Option<&str>) -> Option<String> {
+    let mut command = Command::new(binary);
+    command
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    if let Some(path) = path_env {
+        command.env("PATH", path);
+    }
+
+    let output = tokio::time::timeout(HELPER_PROCESS_TIMEOUT, command.output())
+        .await
+        .ok()?
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!version.is_empty()).then_some(version)
+}
+
+// ---------------------------------------------------------------------------
+// 実行管理
+// ---------------------------------------------------------------------------
+
+/// 1 回の実行に対する制御情報。
+struct RunControl {
+    /// 子プロセスの PID（unix ではプロセスグループ ID も兼ねる）。
+    pid: Option<u32>,
+    /// ユーザーによる停止要求フラグ。
+    cancelled: Arc<AtomicBool>,
+}
+
+/// `start_prompt_run` の入力値。
+pub struct StartPromptRunRequest {
+    pub project_path: String,
+    pub prompt: String,
+    pub permission_mode: PermissionMode,
+    pub resume_session_id: Option<String>,
+    pub model: Option<String>,
+}
+
+/// 実行中の `claude` プロセスを run_id で管理する。
+#[derive(Default)]
+pub struct PromptRunner {
+    runs: Mutex<HashMap<String, RunControl>>,
+}
+
+impl PromptRunner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `runs` のロックを取得する。ロック汚染時もデータ自体は健全なため復帰する。
+    ///
+    /// 注意: 返した guard を `.await` をまたいで保持しないこと。
+    fn runs(&self) -> MutexGuard<'_, HashMap<String, RunControl>> {
+        self.runs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn is_running(&self, run_id: &str) -> bool {
+        self.runs().contains_key(run_id)
+    }
+
+    /// `claude` を起動し、run_id を返す。
+    ///
+    /// 起動に失敗した場合は `Err` を返し、イベントは一切流さない（契約 §3）。
+    pub async fn start(
+        self: &Arc<Self>,
+        app: AppHandle,
+        request: StartPromptRunRequest,
+    ) -> Result<String, String> {
+        let prompt = request.prompt.trim().to_string();
+        if prompt.is_empty() {
+            return Err("プロンプトが空です。".to_string());
+        }
+
+        let working_dir = PathBuf::from(&request.project_path);
+        if !working_dir.is_dir() {
+            return Err(format!(
+                "プロジェクトディレクトリが見つかりません: {}",
+                request.project_path
+            ));
+        }
+
+        let args = build_claude_args(
+            request.permission_mode,
+            request.resume_session_id.as_deref(),
+            request.model.as_deref(),
+        )?;
+
+        let (binary, path_env) = resolve_cli_environment_async().await?;
+
+        let mut command = Command::new(&binary);
+        command
+            .args(&args)
+            .current_dir(&working_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        if let Some(path) = path_env {
+            command.env("PATH", path);
+        }
+        // 停止時にプロセスグループごと終了させるため、リーダーにしておく。
+        #[cfg(unix)]
+        command.process_group(0);
+
+        let mut child = command
+            .spawn()
+            .map_err(|e| format!("Claude Code CLI の起動に失敗しました: {e}"))?;
+
+        let (Some(stdin), Some(stdout), Some(stderr)) =
+            (child.stdin.take(), child.stdout.take(), child.stderr.take())
+        else {
+            let _ = child.kill().await;
+            return Err("子プロセスの入出力ストリームを取得できませんでした。".to_string());
+        };
+
+        let run_id = Uuid::new_v4().to_string();
+        let cancelled = Arc::new(AtomicBool::new(false));
+        self.runs().insert(
+            run_id.clone(),
+            RunControl {
+                pid: child.id(),
+                cancelled: Arc::clone(&cancelled),
+            },
+        );
+
+        let runner = Arc::clone(self);
+        let supervised_run_id = run_id.clone();
+        tokio::spawn(async move {
+            // プロンプトの書き込みは出力の読み取りと並行させる。
+            // 逐次実行にすると、パイプバッファを超える長いプロンプトで
+            // 「CLI は stdout の掃け待ち / こちらは stdin の書き込み待ち」の
+            // デッドロックに陥る。
+            let stdin_task = tokio::spawn(write_prompt_to_stdin(
+                app.clone(),
+                supervised_run_id.clone(),
+                stdin,
+                prompt,
+            ));
+            let stdout_task = tokio::spawn(forward_stdout(
+                app.clone(),
+                supervised_run_id.clone(),
+                stdout,
+            ));
+            let stderr_task = tokio::spawn(forward_stderr(
+                app.clone(),
+                supervised_run_id.clone(),
+                stderr,
+            ));
+
+            let wait_result = child.wait().await;
+
+            // PID 再利用による誤 kill を避けるため、プロセスを回収した直後に登録を解除する。
+            // （登録が残っている間 = 子プロセスが未回収、が保証される）
+            runner.runs().remove(&supervised_run_id);
+
+            // 取りこぼしを防ぐため、両ストリームを読み切ってから exit を流す。
+            let _ = stdin_task.await;
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+
+            let (exit_code, exited_successfully) = match wait_result {
+                Ok(status) => (status.code(), status.success()),
+                Err(e) => {
+                    emit_event(
+                        &app,
+                        PromptRunEvent {
+                            run_id: supervised_run_id.clone(),
+                            kind: PromptRunEventKind::Error,
+                            payload: None,
+                            text: Some(format!("プロセスの終了待機に失敗しました: {e}")),
+                            exit_code: None,
+                            success: None,
+                        },
+                    );
+                    (None, false)
+                }
+            };
+
+            let success = exited_successfully && !cancelled.load(Ordering::SeqCst);
+            emit_event(
+                &app,
+                PromptRunEvent {
+                    run_id: supervised_run_id,
+                    kind: PromptRunEventKind::Exit,
+                    payload: None,
+                    text: None,
+                    exit_code,
+                    success: Some(success),
+                },
+            );
+        });
+
+        Ok(run_id)
+    }
+
+    /// 実行中のプロンプトを停止する。
+    ///
+    /// unix ではプロセスグループ全体に SIGTERM を送り、2 秒待っても終了しなければ
+    /// SIGKILL に切り替える。
+    pub async fn stop(self: &Arc<Self>, run_id: &str) -> Result<(), String> {
+        let pid = {
+            let runs = self.runs();
+            let control = runs
+                .get(run_id)
+                .ok_or_else(|| format!("実行中のプロンプトが見つかりません: {run_id}"))?;
+            control.cancelled.store(true, Ordering::SeqCst);
+            control.pid
+        };
+
+        let Some(pid) = pid else {
+            return Err("プロセス ID を取得できないため停止できません。".to_string());
+        };
+
+        #[cfg(unix)]
+        {
+            signal_process_group(pid, libc::SIGTERM)?;
+
+            for _ in 0..STOP_POLL_ATTEMPTS {
+                tokio::time::sleep(STOP_POLL_INTERVAL).await;
+                if !self.is_running(run_id) {
+                    return Ok(());
+                }
+            }
+
+            signal_process_group(pid, libc::SIGKILL)?;
+        }
+
+        #[cfg(windows)]
+        {
+            terminate_process_tree(pid)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// プロンプトを子プロセスの stdin に書き込み、EOF を伝えるため閉じる。
+///
+/// 出力の読み取りと並行して動かすため独立したタスクとして spawn される。
+/// 子プロセスが先に終了していると EPIPE になるが、その場合は exit イベントで
+/// 状況が伝わるため、エラーイベントは流さず黙って終える。
+async fn write_prompt_to_stdin(
+    app: AppHandle,
+    run_id: String,
+    mut stdin: ChildStdin,
+    prompt: String,
+) {
+    if let Err(e) = stdin.write_all(prompt.as_bytes()).await {
+        if e.kind() != std::io::ErrorKind::BrokenPipe {
+            emit_event(
+                &app,
+                text_event(
+                    &run_id,
+                    PromptRunEventKind::Error,
+                    format!("プロンプトの書き込みに失敗しました: {e}"),
+                ),
+            );
+        }
+        return;
+    }
+
+    // EOF を伝えないと CLI が入力待ちのまま止まるため、必ず閉じる。
+    let _ = stdin.shutdown().await;
+}
+
+/// プロセスグループ全体にシグナルを送る。
+#[cfg(unix)]
+fn signal_process_group(pid: u32, signal: i32) -> Result<(), String> {
+    let pgid = i32::try_from(pid).map_err(|_| "プロセス ID が想定外の値です。".to_string())?;
+
+    // SAFETY: `kill(2)` の FFI 呼び出し。引数はスカラー値のみでポインタを渡さないため、
+    // Rust 側のメモリ安全性に影響しない。第 1 引数を負値にすることでプロセスグループ
+    // (spawn 時に `process_group(0)` で子をリーダーにしたグループ) 全体へ送る。
+    if unsafe { libc::kill(-pgid, signal) } == 0 {
+        return Ok(());
+    }
+
+    let error = std::io::Error::last_os_error();
+    // 既に終了しているだけなら成功扱いにする。
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(format!("プロセスの停止に失敗しました: {error}"))
+    }
+}
+
+/// 子プロセスとその子孫を強制終了する（Windows 用）。
+#[cfg(windows)]
+fn terminate_process_tree(pid: u32) -> Result<(), String> {
+    std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map_err(|e| format!("プロセスの停止に失敗しました: {e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// 出力の中継
+// ---------------------------------------------------------------------------
+
+/// 標準出力を 1 行ずつ読み、stream-json ならそのまま、
+/// パースできなければ stderr 扱いで中継する（出力を捨てない）。
+async fn forward_stdout(app: AppHandle, run_id: String, stdout: ChildStdout) {
+    let mut lines = BufReader::new(stdout).lines();
+
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let event = match serde_json::from_str::<serde_json::Value>(trimmed) {
+                    Ok(payload) => PromptRunEvent {
+                        run_id: run_id.clone(),
+                        kind: PromptRunEventKind::Message,
+                        payload: Some(payload),
+                        text: None,
+                        exit_code: None,
+                        success: None,
+                    },
+                    Err(_) => text_event(&run_id, PromptRunEventKind::Stderr, line),
+                };
+                emit_event(&app, event);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                emit_event(
+                    &app,
+                    text_event(
+                        &run_id,
+                        PromptRunEventKind::Stderr,
+                        format!("標準出力の読み取りに失敗しました: {e}"),
+                    ),
+                );
+                break;
+            }
+        }
+    }
+}
+
+/// 標準エラー出力を 1 行ずつ中継する。
+async fn forward_stderr(app: AppHandle, run_id: String, stderr: ChildStderr) {
+    let mut lines = BufReader::new(stderr).lines();
+
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                emit_event(&app, text_event(&run_id, PromptRunEventKind::Stderr, line));
+            }
+            Ok(None) => break,
+            Err(e) => {
+                emit_event(
+                    &app,
+                    text_event(
+                        &run_id,
+                        PromptRunEventKind::Stderr,
+                        format!("標準エラー出力の読み取りに失敗しました: {e}"),
+                    ),
+                );
+                break;
+            }
+        }
+    }
+}
+
+/// テキスト系（stderr / error）イベントを作る。
+fn text_event(run_id: &str, kind: PromptRunEventKind, text: String) -> PromptRunEvent {
+    PromptRunEvent {
+        run_id: run_id.to_string(),
+        kind,
+        payload: None,
+        text: Some(text),
+        exit_code: None,
+        success: None,
+    }
+}
+
+/// イベントを送信する。送信失敗は致命的ではないためログのみ。
+fn emit_event(app: &AppHandle, event: PromptRunEvent) {
+    if let Err(e) = app.emit(PROMPT_RUN_EVENT, event) {
+        eprintln!("{PROMPT_RUN_EVENT} の送信に失敗しました: {e}");
+    }
+}

--- a/src-tauri/src/tests.rs
+++ b/src-tauri/src/tests.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::claude_data::ClaudeDataManager;
     use crate::models::*;
+    use crate::prompt_runner::build_claude_args;
     use chrono::{DateTime, Utc};
     use std::fs;
     use std::path::Path;
@@ -2109,5 +2110,170 @@ mod tests {
             .to_string()
             .contains("must be within a .claude directory"));
         assert!(!bad_file.exists());
+    }
+
+    // ---------------------------------------------------------------------
+    // Prompt runner
+    // ---------------------------------------------------------------------
+
+    /// `PermissionMode` の JSON 表現と CLI 引数表現が一致していること。
+    #[test]
+    fn test_permission_mode_serialization_matches_cli_arg() {
+        let cases = [
+            (PermissionMode::Plan, "plan"),
+            (PermissionMode::AcceptEdits, "acceptEdits"),
+            (PermissionMode::BypassPermissions, "bypassPermissions"),
+        ];
+
+        for (mode, expected) in cases {
+            assert_eq!(
+                serde_json::to_string(&mode).unwrap(),
+                format!("\"{expected}\"")
+            );
+            assert_eq!(mode.as_cli_arg(), expected);
+        }
+    }
+
+    /// 3 モード × resume あり/なし × model あり/なしの全組み合わせ。
+    #[test]
+    fn test_build_claude_args_all_combinations() {
+        let modes = [
+            PermissionMode::Plan,
+            PermissionMode::AcceptEdits,
+            PermissionMode::BypassPermissions,
+        ];
+        let resume_ids = [None, Some("0199a1b2-3c4d-5e6f-8a9b-0c1d2e3f4a5b")];
+        let models = [None, Some("claude-sonnet-4-5")];
+
+        for mode in modes {
+            for resume_session_id in resume_ids {
+                for model in models {
+                    let args = build_claude_args(mode, resume_session_id, model)
+                        .expect("valid arguments should be accepted");
+
+                    let mut expected = vec![
+                        "-p",
+                        "--output-format",
+                        "stream-json",
+                        "--verbose",
+                        "--permission-mode",
+                        mode.as_cli_arg(),
+                    ];
+                    if let Some(session_id) = resume_session_id {
+                        expected.push("--resume");
+                        expected.push(session_id);
+                    }
+                    if let Some(model) = model {
+                        expected.push("--model");
+                        expected.push(model);
+                    }
+
+                    assert_eq!(args, expected, "mode={mode:?}");
+                }
+            }
+        }
+    }
+
+    /// 不正なセッション ID は引数インジェクションを防ぐために拒否されること。
+    #[test]
+    fn test_build_claude_args_rejects_invalid_session_id() {
+        let too_long = "a".repeat(65);
+        let invalid_values = [
+            "--dangerously-skip-permissions",
+            "a b",
+            "",
+            too_long.as_str(),
+            "a;b",
+            "../etc/passwd",
+        ];
+
+        for value in invalid_values {
+            let result = build_claude_args(PermissionMode::Plan, Some(value), None);
+            assert!(
+                result.is_err(),
+                "session_id {value:?} should have been rejected"
+            );
+        }
+    }
+
+    /// 不正なモデル名は拒否されること。
+    #[test]
+    fn test_build_claude_args_rejects_invalid_model() {
+        let too_long = "a".repeat(65);
+        let invalid_values = ["-x", "a;b", "", too_long.as_str(), "a b", "$(whoami)"];
+
+        for value in invalid_values {
+            let result = build_claude_args(PermissionMode::Plan, None, Some(value));
+            assert!(result.is_err(), "model {value:?} should have been rejected");
+        }
+    }
+
+    /// 境界値: 64 文字はセーフ、65 文字はアウト。
+    #[test]
+    fn test_build_claude_args_length_boundary() {
+        let max_len_value = "a".repeat(64);
+        assert!(build_claude_args(PermissionMode::Plan, Some(&max_len_value), None).is_ok());
+        assert!(build_claude_args(PermissionMode::Plan, None, Some(&max_len_value)).is_ok());
+
+        let over_len_value = "a".repeat(65);
+        assert!(build_claude_args(PermissionMode::Plan, Some(&over_len_value), None).is_err());
+        assert!(build_claude_args(PermissionMode::Plan, None, Some(&over_len_value)).is_err());
+    }
+
+    /// `PromptRunEvent` が契約どおり snake_case のキーでシリアライズされること。
+    #[test]
+    fn test_prompt_run_event_serialization() {
+        let message_event = PromptRunEvent {
+            run_id: "run-1".to_string(),
+            kind: PromptRunEventKind::Message,
+            payload: Some(serde_json::json!({"type": "system", "session_id": "s-1"})),
+            text: None,
+            exit_code: None,
+            success: None,
+        };
+
+        let json = serde_json::to_value(&message_event).unwrap();
+        assert_eq!(json["run_id"], "run-1");
+        assert_eq!(json["kind"], "message");
+        assert_eq!(json["payload"]["type"], "system");
+        assert_eq!(json["payload"]["session_id"], "s-1");
+        assert!(json["text"].is_null());
+        assert!(json["exit_code"].is_null());
+        assert!(json["success"].is_null());
+
+        let exit_event = PromptRunEvent {
+            run_id: "run-1".to_string(),
+            kind: PromptRunEventKind::Exit,
+            payload: None,
+            text: None,
+            exit_code: Some(0),
+            success: Some(true),
+        };
+
+        let json = serde_json::to_value(&exit_event).unwrap();
+        assert_eq!(json["run_id"], "run-1");
+        assert_eq!(json["kind"], "exit");
+        assert_eq!(json["exit_code"], 0);
+        assert_eq!(json["success"], true);
+        assert!(json["payload"].is_null());
+        assert!(json["text"].is_null());
+    }
+
+    /// イベント種別が snake_case で表現されること。
+    #[test]
+    fn test_prompt_run_event_kind_serialization() {
+        let cases = [
+            (PromptRunEventKind::Message, "message"),
+            (PromptRunEventKind::Stderr, "stderr"),
+            (PromptRunEventKind::Exit, "exit"),
+            (PromptRunEventKind::Error, "error"),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(
+                serde_json::to_string(&kind).unwrap(),
+                format!("\"{expected}\"")
+            );
+        }
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -2259,7 +2259,11 @@ button:hover:not(:disabled) {
 .project-screen {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  /* 100vh だとナビ + .main の padding の分だけ画面下にはみ出し、
+     最下部（Prompt タブのコンポーザー等）が見えなくなる。
+     .main は .app(100vh) 内の flex アイテムで高さが確定しているため
+     100% で「残りの高さちょうど」に収まる。 */
+  height: 100%;
   overflow: hidden;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import "./styles/editors.css";
 import "./styles/design-tokens.css";
 import "./styles/improved-settings.css";
 import "./styles/command-history-migration.css";
+import "./styles/prompt-runner.css";
 import { Dashboard } from "./components/Dashboard";
 import { SessionBrowser } from "./components/SessionBrowser";
 import { ProjectScreen } from "./components/ProjectScreen";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import "./App.css";
 import "./styles/editors.css";
 import "./styles/design-tokens.css";
 import "./styles/improved-settings.css";
 import "./styles/command-history-migration.css";
 import "./styles/prompt-runner.css";
+import "./styles/prompt-runs.css";
 import { Dashboard } from "./components/Dashboard";
 import { SessionBrowser } from "./components/SessionBrowser";
 import { ProjectScreen } from "./components/ProjectScreen";
@@ -12,6 +13,11 @@ import { CommandHistory } from "./components/CommandHistory";
 import { TodoManager } from "./components/TodoManager";
 import { SettingsEditor } from "./components/SettingsEditor";
 import { ImprovedSettingsEditor } from "./components/improved/ImprovedSettingsEditor";
+import { PromptsOverview } from "./components/PromptsOverview";
+import {
+  PromptRunsProvider,
+  usePromptRuns,
+} from "./contexts/PromptRunsContext";
 import { api } from "./api";
 import { setHomeDirCache } from "./utils/pathUtils";
 import "./utils/improvedSettings"; // Initialize improved settings utilities
@@ -22,11 +28,42 @@ type Tab =
   | "commands"
   | "todos"
   | "settings"
-  | "project";
+  | "project"
+  | "prompts";
+
+/**
+ * ナビの Prompts ボタン。実行中の件数バッジを表示するため、
+ * PromptRunsProvider 配下で hook を使う小コンポーネントに分離している。
+ */
+const PromptsNavButton: React.FC<{
+  active: boolean;
+  onClick: () => void;
+}> = ({ active, onClick }) => {
+  const { runningCount } = usePromptRuns();
+  return (
+    <button className={active ? "active" : ""} onClick={onClick}>
+      Prompts
+      {runningCount > 0 && (
+        <span
+          className="nav-running-badge"
+          aria-label={`${runningCount} 件実行中`}
+        >
+          <span className="nav-running-badge__dot" aria-hidden="true" />
+          {runningCount}
+        </span>
+      )}
+    </button>
+  );
+};
 
 function App() {
   const [activeTab, setActiveTab] = useState<Tab>("dashboard");
   const [selectedProjectPath, setSelectedProjectPath] = useState<string>("");
+  // Prompt タブを開いた状態でプロジェクト画面へ遷移させるためのリクエスト。
+  // 同じプロジェクトを連続で開いても効くよう nonce で毎回変化させる。
+  const [promptTabRequest, setPromptTabRequest] = useState<{ nonce: number }>({
+    nonce: 0,
+  });
 
   // Enable improved settings editor with URL parameter or localStorage flag
   const [useImprovedSettings] = useState(() => {
@@ -67,6 +104,13 @@ function App() {
     setActiveTab("project");
   };
 
+  /** プロジェクト画面を Prompt タブが開いた状態で表示する */
+  const navigateToProjectPrompt = (projectPath: string) => {
+    setSelectedProjectPath(projectPath);
+    setPromptTabRequest((prev) => ({ nonce: prev.nonce + 1 }));
+    setActiveTab("project");
+  };
+
   const navigateBackToDashboard = () => {
     setActiveTab("dashboard");
   };
@@ -74,11 +118,23 @@ function App() {
   const renderActiveTab = () => {
     switch (activeTab) {
       case "dashboard":
-        return <Dashboard onProjectClick={navigateToProject} />;
+        return (
+          <Dashboard
+            onProjectClick={navigateToProject}
+            onOpenPromptRun={navigateToProjectPrompt}
+          />
+        );
       case "sessions":
         return <SessionBrowser />;
       case "project":
-        return <ProjectScreen projectPath={selectedProjectPath} />;
+        return (
+          <ProjectScreen
+            projectPath={selectedProjectPath}
+            promptTabRequest={promptTabRequest}
+          />
+        );
+      case "prompts":
+        return <PromptsOverview onOpenProject={navigateToProjectPrompt} />;
       case "commands":
         return <CommandHistory />;
       case "todos":
@@ -95,58 +151,64 @@ function App() {
   };
 
   return (
-    <div className="app">
-      <nav className="nav">
-        <h1
-          className="nav-title clickable"
-          onClick={navigateBackToDashboard}
-          role="button"
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              navigateBackToDashboard();
-            }
-          }}
-          title="Back to Dashboard"
-        >
-          Claude Code Manager
-        </h1>
-        <div className="nav-tabs">
-          <button
-            className={activeTab === "dashboard" ? "active" : ""}
-            onClick={() => setActiveTab("dashboard")}
+    <PromptRunsProvider>
+      <div className="app">
+        <nav className="nav">
+          <h1
+            className="nav-title clickable"
+            onClick={navigateBackToDashboard}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                navigateBackToDashboard();
+              }
+            }}
+            title="Back to Dashboard"
           >
-            Dashboard
-          </button>
-          <button
-            className={activeTab === "sessions" ? "active" : ""}
-            onClick={() => setActiveTab("sessions")}
-          >
-            Sessions
-          </button>
-          <button
-            className={activeTab === "commands" ? "active" : ""}
-            onClick={() => setActiveTab("commands")}
-          >
-            Commands
-          </button>
-          <button
-            className={activeTab === "todos" ? "active" : ""}
-            onClick={() => setActiveTab("todos")}
-          >
-            TODOs
-          </button>
-          <button
-            className={activeTab === "settings" ? "active" : ""}
-            onClick={() => setActiveTab("settings")}
-          >
-            Settings
-          </button>
-        </div>
-      </nav>
-      <main className="main">{renderActiveTab()}</main>
-    </div>
+            Claude Code Manager
+          </h1>
+          <div className="nav-tabs">
+            <button
+              className={activeTab === "dashboard" ? "active" : ""}
+              onClick={() => setActiveTab("dashboard")}
+            >
+              Dashboard
+            </button>
+            <button
+              className={activeTab === "sessions" ? "active" : ""}
+              onClick={() => setActiveTab("sessions")}
+            >
+              Sessions
+            </button>
+            <button
+              className={activeTab === "commands" ? "active" : ""}
+              onClick={() => setActiveTab("commands")}
+            >
+              Commands
+            </button>
+            <button
+              className={activeTab === "todos" ? "active" : ""}
+              onClick={() => setActiveTab("todos")}
+            >
+              TODOs
+            </button>
+            <PromptsNavButton
+              active={activeTab === "prompts"}
+              onClick={() => setActiveTab("prompts")}
+            />
+            <button
+              className={activeTab === "settings" ? "active" : ""}
+              onClick={() => setActiveTab("settings")}
+            >
+              Settings
+            </button>
+          </div>
+        </nav>
+        <main className="main">{renderActiveTab()}</main>
+      </div>
+    </PromptRunsProvider>
   );
 }
 

--- a/src/api-mock.ts
+++ b/src/api-mock.ts
@@ -9,6 +9,9 @@ import type {
   SessionStats,
   CustomCommand,
   Agent,
+  ClaudeCliStatus,
+  PromptRunEvent,
+  StartPromptRunParams,
 } from "./types";
 
 // Mock data for demonstration
@@ -177,6 +180,46 @@ const mockSettings: ClaudeSettings = {
     ],
   },
 };
+
+// ============================================================================
+// Prompt runner mock: 疑似イベントバス
+// ブラウザ単体開発（npm run dev）で UI を確認するためのもの
+// ============================================================================
+
+type PromptRunEventHandler = (event: PromptRunEvent) => void;
+
+/**
+ * 購読 1 件を表すラッパー。
+ *
+ * Tauri の `listen()` は同じ関数を 2 回渡しても別々の購読になる。
+ * handler をそのまま Set に入れると参照が同一のときに 1 件へ潰れてしまい、
+ * StrictMode の「購読 → 解除 → 購読」で最後に残るはずの購読まで消える。
+ * 実挙動を揃えるため、購読ごとに固有のオブジェクトを持たせる。
+ */
+type PromptRunSubscription = { handler: PromptRunEventHandler };
+
+const promptRunSubscriptions = new Set<PromptRunSubscription>();
+const promptRunTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
+let promptRunSeq = 0;
+
+function emitPromptRunEvent(event: PromptRunEvent): void {
+  // 配信中に解除されても走査が壊れないようコピーを回す。
+  for (const subscription of [...promptRunSubscriptions]) {
+    subscription.handler(event);
+  }
+}
+
+function clearPromptRunTimers(runId: string): void {
+  const timers = promptRunTimers.get(runId);
+  if (timers) {
+    for (const timer of timers) {
+      clearTimeout(timer);
+    }
+    promptRunTimers.delete(runId);
+  }
+}
+
+const MOCK_SESSION_ID = "3f9a1c72-4b8e-4c1d-9f2a-6d5b8e7c1a90";
 
 // Mock API implementation
 export const mockApi = {
@@ -447,5 +490,175 @@ export const mockApi = {
   async saveSettings(settings: ClaudeSettings): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 200));
     console.log(`Mock: Would save settings:`, settings);
+  },
+
+  // --------------------------------------------------------------------------
+  // In-app prompt runner
+  // --------------------------------------------------------------------------
+
+  async getClaudeCliStatus(): Promise<ClaudeCliStatus> {
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    return {
+      available: true,
+      path: "/usr/local/bin/claude",
+      version: "2.1.226 (Claude Code)",
+    };
+  },
+
+  async startPromptRun(params: StartPromptRunParams): Promise<string> {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    promptRunSeq += 1;
+    const runId = `mock-run-${promptRunSeq}`;
+    const sessionId = params.resumeSessionId ?? MOCK_SESSION_ID;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    const schedule = (delay: number, event: PromptRunEvent): void => {
+      timers.push(
+        setTimeout(() => {
+          if (event.kind === "exit") {
+            clearPromptRunTimers(runId);
+          }
+          emitPromptRunEvent(event);
+        }, delay),
+      );
+    };
+
+    schedule(200, {
+      run_id: runId,
+      kind: "message",
+      payload: {
+        type: "system",
+        subtype: "init",
+        session_id: sessionId,
+        model: params.model ?? "claude-sonnet-4-6",
+        cwd: params.projectPath,
+        tools: ["Read", "Grep", "Bash"],
+        permissionMode: params.permissionMode,
+      },
+    });
+
+    schedule(600, {
+      run_id: runId,
+      kind: "message",
+      payload: {
+        type: "assistant",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: `了解しました。\`${params.projectPath}\` を調べます。\n\n- まずファイルを読みます\n- 次に要約します`,
+            },
+          ],
+        },
+      },
+    });
+
+    schedule(1100, {
+      run_id: runId,
+      kind: "message",
+      payload: {
+        type: "assistant",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_mock_1",
+              name: "Read",
+              input: { file_path: `${params.projectPath}/package.json` },
+            },
+          ],
+        },
+      },
+    });
+
+    schedule(1600, {
+      run_id: runId,
+      kind: "message",
+      payload: {
+        type: "user",
+        session_id: sessionId,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_mock_1",
+              content:
+                '{\n  "name": "claude-code-manager",\n  "version": "0.1.0"\n}',
+              is_error: false,
+            },
+          ],
+        },
+      },
+    });
+
+    schedule(2100, {
+      run_id: runId,
+      kind: "message",
+      payload: {
+        type: "assistant",
+        session_id: sessionId,
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "**完了しました。** `claude-code-manager` v0.1.0 のプロジェクトです。",
+            },
+          ],
+        },
+      },
+    });
+
+    schedule(2400, {
+      run_id: runId,
+      kind: "message",
+      payload: {
+        type: "result",
+        subtype: "success",
+        session_id: sessionId,
+        is_error: false,
+        duration_ms: 2400,
+        num_turns: 3,
+        total_cost_usd: 0.0123,
+        result: "完了しました。",
+      },
+    });
+
+    schedule(2500, {
+      run_id: runId,
+      kind: "exit",
+      exit_code: 0,
+      success: true,
+    });
+
+    promptRunTimers.set(runId, timers);
+    return runId;
+  },
+
+  async stopPromptRun(runId: string): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    clearPromptRunTimers(runId);
+    emitPromptRunEvent({
+      run_id: runId,
+      kind: "exit",
+      exit_code: 143,
+      success: false,
+    });
+  },
+
+  async onPromptRunEvent(
+    handler: (event: PromptRunEvent) => void,
+  ): Promise<() => void> {
+    const subscription: PromptRunSubscription = { handler };
+    promptRunSubscriptions.add(subscription);
+    return () => {
+      promptRunSubscriptions.delete(subscription);
+    };
   },
 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,6 +10,9 @@ import type {
   ClaudeDirectoryInfo,
   CustomCommand,
   Agent,
+  ClaudeCliStatus,
+  PromptRunEvent,
+  StartPromptRunParams,
 } from "./types";
 
 // Check if we're running in Tauri environment
@@ -268,6 +271,51 @@ export const api = {
       return tauriApi.invoke("save_settings_file", { filename, content });
     }
     return mockApi.saveSettingsFile(filename, content);
+  },
+
+  // In-app prompt runner
+  async getClaudeCliStatus(): Promise<ClaudeCliStatus> {
+    if (isTauri && tauriApi) {
+      return tauriApi.invoke("get_claude_cli_status");
+    }
+    return mockApi.getClaudeCliStatus();
+  },
+
+  async startPromptRun(params: StartPromptRunParams): Promise<string> {
+    if (isTauri && tauriApi) {
+      return tauriApi.invoke("start_prompt_run", {
+        projectPath: params.projectPath,
+        prompt: params.prompt,
+        permissionMode: params.permissionMode,
+        resumeSessionId: params.resumeSessionId ?? null,
+        model: params.model ?? null,
+      });
+    }
+    return mockApi.startPromptRun(params);
+  },
+
+  async stopPromptRun(runId: string): Promise<void> {
+    if (isTauri && tauriApi) {
+      return tauriApi.invoke("stop_prompt_run", { runId });
+    }
+    return mockApi.stopPromptRun(runId);
+  },
+
+  /**
+   * `prompt-run-event` を購読する。戻り値の関数を呼ぶと購読解除される。
+   */
+  async onPromptRunEvent(
+    handler: (event: PromptRunEvent) => void,
+  ): Promise<() => void> {
+    if (isTauri && tauriApi) {
+      const { listen } = await import("@tauri-apps/api/event");
+      const unlisten = await listen<PromptRunEvent>(
+        "prompt-run-event",
+        (event) => handler(event.payload),
+      );
+      return unlisten;
+    }
+    return mockApi.onPromptRunEvent(handler);
   },
 
   // Cache management

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,11 +1,102 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { api } from "../api";
+import {
+  formatElapsed,
+  RUN_STATUS_META,
+  usePromptRunsOptional,
+  type PromptRunInfo,
+} from "../contexts/PromptRunsContext";
 import { formatDateForContext } from "../utils/dateUtils";
+import { getProjectDisplayName } from "../utils/pathUtils";
 import type { SessionStats, ProjectSummary } from "../types";
 
 interface DashboardProps {
   onProjectClick?: (projectPath: string) => void;
+  /** 実行中プロンプトの行やバッジから Prompt タブ直行で開く */
+  onOpenPromptRun?: (projectPath: string) => void;
 }
+
+/** Dashboard 上部の「実行中のプロンプト」セクション */
+const RunningPromptsSection: React.FC<{
+  runs: PromptRunInfo[];
+  onOpen?: (projectPath: string) => void;
+  onStop: (runId: string) => void;
+}> = ({ runs, onOpen, onStop }) => {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (runs.length === 0) return null;
+
+  return (
+    <section
+      className="dashboard-running-section"
+      aria-labelledby="running-prompts-heading"
+    >
+      <div className="section-header">
+        <h2 id="running-prompts-heading" className="section-title">
+          ▶ 実行中のプロンプト ({runs.length})
+        </h2>
+      </div>
+      <ul className="dashboard-running-section__list">
+        {runs.map((run) => (
+          <li
+            key={run.runId}
+            className="prompt-runs-row prompt-runs-row--running"
+          >
+            <span
+              className="prompt-runs-row__icon prompt-runs-row__icon--running"
+              role="img"
+              aria-label="実行中"
+            >
+              {RUN_STATUS_META.running.icon}
+            </span>
+            <div className="prompt-runs-row__body">
+              <div className="prompt-runs-row__title">
+                <span className="prompt-runs-row__project">
+                  {getProjectDisplayName(run.projectPath)}
+                </span>
+                <span className="prompt-runs-row__meta">
+                  <span>{formatElapsed(now - run.startedAt)}</span>
+                  <span>{run.permissionMode}</span>
+                </span>
+              </div>
+              <div className="prompt-runs-row__prompt" title={run.prompt}>
+                {run.prompt}
+              </div>
+              {run.lastActivity && (
+                <div className="prompt-runs-row__activity">
+                  {run.lastActivity}
+                </div>
+              )}
+            </div>
+            <div className="prompt-runs-row__actions">
+              <button
+                type="button"
+                className="prompt-runs-row__button"
+                onClick={() => onStop(run.runId)}
+              >
+                停止
+              </button>
+              {onOpen && (
+                <button
+                  type="button"
+                  className="prompt-runs-row__button prompt-runs-row__button--primary"
+                  onClick={() => onOpen(run.projectPath)}
+                >
+                  開く
+                </button>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
 
 const StatCard: React.FC<{
   title: string;
@@ -38,7 +129,9 @@ const StatCard: React.FC<{
 const ProjectCard: React.FC<{
   project: ProjectSummary;
   onClick: () => void;
-}> = ({ project, onClick }) => {
+  /** このプロジェクトの最新のプロンプト実行（無ければ null） */
+  latestRun?: PromptRunInfo | null;
+}> = ({ project, onClick, latestRun }) => {
   const projectName =
     project.project_path.split("/").pop() || project.project_path;
   const isActive = project.ide_info?.pid;
@@ -87,6 +180,15 @@ const ProjectCard: React.FC<{
               <span className="active-badge">
                 <span className="active-pulse"></span>
                 Active
+              </span>
+            )}
+            {latestRun && (
+              <span
+                className={`project-run-badge project-run-badge--${latestRun.status}`}
+                title={`プロンプト: ${latestRun.prompt}`}
+              >
+                {RUN_STATUS_META[latestRun.status].icon}{" "}
+                {RUN_STATUS_META[latestRun.status].label}
               </span>
             )}
           </div>
@@ -184,7 +286,24 @@ const LoadingSkeleton: React.FC = () => (
   </div>
 );
 
-export const Dashboard: React.FC<DashboardProps> = ({ onProjectClick }) => {
+export const Dashboard: React.FC<DashboardProps> = ({
+  onProjectClick,
+  onOpenPromptRun,
+}) => {
+  // Provider 配下でなければ null（既存テストの単体レンダリング等）
+  const runsStore = usePromptRunsOptional();
+  const runningRuns =
+    runsStore?.runs.filter((run) => run.status === "running") ?? [];
+
+  const handleStopRun = useCallback(
+    (runId: string) => {
+      runsStore?.stopRun(runId).catch((error: unknown) => {
+        console.error("Failed to stop prompt run:", error);
+      });
+    },
+    [runsStore],
+  );
+
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -299,6 +418,12 @@ export const Dashboard: React.FC<DashboardProps> = ({ onProjectClick }) => {
         </div>
       </header>
 
+      <RunningPromptsSection
+        runs={runningRuns}
+        onOpen={onOpenPromptRun}
+        onStop={handleStopRun}
+      />
+
       <section className="stats-section" aria-labelledby="stats-heading">
         <div className="section-header">
           <h2 id="stats-heading" className="section-title">
@@ -375,6 +500,10 @@ export const Dashboard: React.FC<DashboardProps> = ({ onProjectClick }) => {
               <ProjectCard
                 key={project.project_path}
                 project={project}
+                latestRun={
+                  runsStore?.latestRunByProject.get(project.project_path) ??
+                  null
+                }
                 onClick={() => onProjectClick?.(project.project_path)}
               />
             ))}

--- a/src/components/ProjectScreen.tsx
+++ b/src/components/ProjectScreen.tsx
@@ -6,6 +6,7 @@ import {
   getProjectDisplayName,
 } from "../utils/pathUtils";
 import { useToast, ToastContainer } from "./Toast";
+import { PromptRunner } from "./PromptRunner";
 import { formatDateTime, formatDateTooltip } from "../utils/dateUtils";
 import type {
   ClaudeSession,
@@ -34,9 +35,11 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
   const [loading, setLoading] = useState(true);
   const [loadingMessages, setLoadingMessages] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"sessions" | "directory">(
-    "sessions",
-  );
+  const [activeTab, setActiveTab] = useState<
+    "sessions" | "directory" | "prompt"
+  >("sessions");
+  // Prompt タブを一度でも開いたか（開くまで PromptRunner をマウントしない）
+  const [promptTabVisited, setPromptTabVisited] = useState(false);
   const [knownProjectPaths, setKnownProjectPaths] = useState<string[]>([]);
   const [claudeDirectoryInfo, setClaudeDirectoryInfo] =
     useState<ClaudeDirectoryInfo | null>(null);
@@ -318,6 +321,31 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
       setIsRefreshing(false);
     }
   }, [activeTab, selectedSession, projectPath, toast]);
+
+  /**
+   * プロンプト実行の完了後にセッション一覧だけを静かに更新する。
+   *
+   * loadProjectData は `loading` を立てて画面全体をローディング表示に
+   * 差し替えるため、Prompt タブごと unmount され会話ログが消えてしまう。
+   * ここでは表示を保ったままデータだけ差し替える。
+   */
+  const reloadSessionsQuietly = useCallback(async () => {
+    try {
+      await api.clearCache();
+      const [allSessions, projectSummaries] = await Promise.all([
+        api.getAllSessions(),
+        api.getProjectSummary(),
+      ]);
+      setSessions(
+        allSessions.filter((session) => session.project_path === projectPath),
+      );
+      setProjectSummary(
+        projectSummaries.find((p) => p.project_path === projectPath) ?? null,
+      );
+    } catch (err) {
+      console.error("Failed to refresh sessions after prompt run:", err);
+    }
+  }, [projectPath]);
 
   // Keyboard shortcut for refresh
   useEffect(() => {
@@ -801,6 +829,20 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
             <div className="tab-subtitle">Project configuration</div>
           </div>
         </button>
+        <button
+          className={`tab-button ${activeTab === "prompt" ? "active" : ""}`}
+          onClick={() => {
+            setPromptTabVisited(true);
+            setActiveTab("prompt");
+          }}
+          aria-label="Run a prompt against this project"
+        >
+          <div className="tab-icon">✨</div>
+          <div className="tab-content">
+            <div className="tab-title">Prompt</div>
+            <div className="tab-subtitle">Claude に指示を出す</div>
+          </div>
+        </button>
       </div>
 
       {activeTab === "sessions" ? (
@@ -1028,7 +1070,7 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
             )}
           </div>
         </div>
-      ) : (
+      ) : activeTab === "prompt" ? null : (
         <div className="project-directory-content">
           <div className="claude-directory-files">
             <h3>.claude Directory</h3>
@@ -1214,6 +1256,23 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
               )}
             </div>
           )}
+        </div>
+      )}
+
+      {/*
+        Prompt タブは一度開いたらマウントしたままにし、非表示にするだけにする。
+        タブを行き来しても会話ログと実行中のセッションが失われないようにするため。
+        未訪問のうちはマウントしない（CLI 検出のためのプロセス起動を避ける）。
+      */}
+      {promptTabVisited && (
+        <div
+          className="project-prompt-content"
+          style={activeTab === "prompt" ? undefined : { display: "none" }}
+        >
+          <PromptRunner
+            projectPath={normalizedPath}
+            onRunFinished={reloadSessionsQuietly}
+          />
         </div>
       )}
 

--- a/src/components/ProjectScreen.tsx
+++ b/src/components/ProjectScreen.tsx
@@ -19,10 +19,16 @@ import type {
 
 interface ProjectScreenProps {
   projectPath: string;
+  /**
+   * Prompt タブを開いた状態で表示するリクエスト（Dashboard / Prompts 一覧から）。
+   * nonce が変わるたびに Prompt タブへ切り替える。0 は「リクエストなし」。
+   */
+  promptTabRequest?: { nonce: number };
 }
 
 export const ProjectScreen: React.FC<ProjectScreenProps> = ({
   projectPath,
+  promptTabRequest,
 }) => {
   const [sessions, setSessions] = useState<ClaudeSession[]>([]);
   const [selectedSession, setSelectedSession] = useState<ClaudeSession | null>(
@@ -123,6 +129,15 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
   useEffect(() => {
     loadProjectData();
   }, [projectPath]);
+
+  // Dashboard / Prompts 一覧からの「Prompt タブで開く」リクエストに応える
+  const promptTabRequestNonce = promptTabRequest?.nonce ?? 0;
+  useEffect(() => {
+    if (promptTabRequestNonce > 0) {
+      setPromptTabVisited(true);
+      setActiveTab("prompt");
+    }
+  }, [promptTabRequestNonce]);
 
   useEffect(() => {
     if (activeTab === "directory") {

--- a/src/components/PromptRunner.tsx
+++ b/src/components/PromptRunner.tsx
@@ -17,6 +17,7 @@ import React, {
   useState,
 } from "react";
 import { api } from "../api";
+import { usePromptRunsOptional } from "../contexts/PromptRunsContext";
 import type {
   ClaudeCliStatus,
   PermissionMode,
@@ -393,6 +394,9 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
+  // アプリ全体の実行状況ストア（Provider 配下でない場合は null で無効化）
+  const runsStore = usePromptRunsOptional();
+
   // イベントハンドラを張り替えないための ref 群
   const runIdRef = useRef<string | null>(null);
   const sessionIdRef = useRef<string | null>(null);
@@ -668,6 +672,13 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
       runIdRef.current = runId;
       pendingRef.current = false;
       flushEventBuffer(runId);
+      // アプリ全体の実行状況ストアにも登録する（Prompts タブ / Dashboard 用）
+      runsStore?.registerRun(runId, {
+        projectPath,
+        prompt: text,
+        permissionMode,
+        model: model === "" ? null : model,
+      });
     } catch (error: unknown) {
       runIdRef.current = null;
       pendingRef.current = false;
@@ -689,6 +700,7 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
     model,
     clearEventBuffer,
     flushEventBuffer,
+    runsStore,
   ]);
 
   const handleSubmit = useCallback(() => {

--- a/src/components/PromptRunner.tsx
+++ b/src/components/PromptRunner.tsx
@@ -1,0 +1,916 @@
+/**
+ * PromptRunner — アプリ内から `claude` CLI をヘッドレス起動し、
+ * stream-json 出力をリアルタイム表示するコンポーネント。
+ *
+ * SECURITY: assistant の markdown は marked でレンダリングした後、
+ * 必ず DOMPurify.sanitize() を通してから dangerouslySetInnerHTML に渡す。
+ * CLI 出力は外部由来の信頼できない入力とみなす。
+ */
+
+import DOMPurify from "isomorphic-dompurify";
+import { marked } from "marked";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { api } from "../api";
+import type {
+  ClaudeCliStatus,
+  PermissionMode,
+  PromptRunEvent,
+  StreamContentBlock,
+} from "../types";
+import { SafeConfirmDialog } from "./SafeConfirmDialog";
+
+// ============================================================================
+// 定数
+// ============================================================================
+
+/** ツール入力の要約に使うキー（先に見つかったものを採用） */
+const TOOL_SUMMARY_KEYS = [
+  "file_path",
+  "command",
+  "pattern",
+  "path",
+  "prompt",
+] as const;
+
+/** 要約の最大文字数 */
+const SUMMARY_MAX_LENGTH = 120;
+
+/** tool_result 展開時に表示する最大文字数 */
+const TOOL_RESULT_MAX_LENGTH = 4000;
+
+/** 自動スクロールを追従させる下端からの距離(px) */
+const STICK_TO_BOTTOM_THRESHOLD = 80;
+
+/**
+ * run_id 確定前に届いたイベントを溜めるバッファの上限。
+ * 超えた分は古いものから捨てる（メモリリーク防止）。
+ */
+const BUFFERED_EVENT_LIMIT = 500;
+
+const PERMISSION_MODE_OPTIONS: ReadonlyArray<{
+  value: PermissionMode;
+  label: string;
+}> = [
+  { value: "plan", label: "読み取り専用" },
+  { value: "acceptEdits", label: "編集を自動承認" },
+  { value: "bypassPermissions", label: "全許可（危険）" },
+];
+
+const MODEL_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "", label: "既定" },
+  { value: "opus", label: "opus" },
+  { value: "sonnet", label: "sonnet" },
+  { value: "haiku", label: "haiku" },
+];
+
+// ============================================================================
+// 会話ログのエントリ型
+// ============================================================================
+
+type LogEntry =
+  | { id: string; kind: "prompt"; text: string }
+  | {
+      id: string;
+      kind: "block";
+      role: "assistant" | "user";
+      block: StreamContentBlock;
+    }
+  | {
+      id: string;
+      kind: "result";
+      durationMs?: number;
+      numTurns?: number;
+      costUsd?: number;
+      isError?: boolean;
+    }
+  | { id: string; kind: "error"; text: string }
+  | { id: string; kind: "exit"; success: boolean; exitCode?: number };
+
+let entrySeq = 0;
+const nextEntryId = (): string => {
+  entrySeq += 1;
+  return `prompt-entry-${entrySeq}`;
+};
+
+// ============================================================================
+// ユーティリティ（副作用なしの純粋関数：テストしやすさのため外出し）
+// ============================================================================
+
+const truncate = (value: string, max: number): string =>
+  value.length > max ? `${value.slice(0, max)}…` : value;
+
+const toErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "不明なエラーが発生しました";
+};
+
+/** marked の出力を必ずサニタイズしてから返す */
+const renderMarkdown = (text: string): string => {
+  try {
+    const html = marked.parse(text, { async: false });
+    return DOMPurify.sanitize(typeof html === "string" ? html : text);
+  } catch {
+    return DOMPurify.sanitize(text);
+  }
+};
+
+/** tool_use の入力を 1 行に要約する */
+export const summarizeToolInput = (input: Record<string, unknown>): string => {
+  for (const key of TOOL_SUMMARY_KEYS) {
+    const value = input[key];
+    if (value === undefined || value === null) continue;
+    const text = typeof value === "string" ? value : JSON.stringify(value);
+    if (text && text.length > 0) return truncate(text, SUMMARY_MAX_LENGTH);
+  }
+  try {
+    return truncate(JSON.stringify(input) ?? "", SUMMARY_MAX_LENGTH);
+  } catch {
+    return "";
+  }
+};
+
+/** tool_result の content を表示可能な文字列にする */
+const stringifyToolResult = (content: unknown): string => {
+  if (content === undefined || content === null) return "";
+  if (typeof content === "string") return content;
+  try {
+    return JSON.stringify(content, null, 2);
+  } catch {
+    return String(content);
+  }
+};
+
+// ============================================================================
+// 表示用サブコンポーネント（高頻度イベントに備えて memo 化）
+// ============================================================================
+
+const MarkdownText = React.memo<{ text: string }>(({ text }) => {
+  const html = useMemo(() => renderMarkdown(text), [text]);
+  return (
+    <div
+      className="prompt-runner__markdown"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: DOMPurify でサニタイズ済み
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+});
+MarkdownText.displayName = "MarkdownText";
+
+const ThinkingBlock = React.memo<{ text: string }>(({ text }) => {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="prompt-runner__thinking">
+      <button
+        type="button"
+        className="prompt-runner__disclosure"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span aria-hidden="true">{expanded ? "▾" : "▸"}</span> 思考プロセス
+      </button>
+      {expanded && <pre className="prompt-runner__pre">{text}</pre>}
+    </div>
+  );
+});
+ThinkingBlock.displayName = "ThinkingBlock";
+
+const ToolUseBlock = React.memo<{
+  name: string;
+  input: Record<string, unknown>;
+}>(({ name, input }) => {
+  const [expanded, setExpanded] = useState(false);
+  const summary = useMemo(() => summarizeToolInput(input), [input]);
+  const raw = useMemo(() => {
+    try {
+      return JSON.stringify(input, null, 2);
+    } catch {
+      return "";
+    }
+  }, [input]);
+
+  return (
+    <div className="prompt-runner__tool-use">
+      <button
+        type="button"
+        className="prompt-runner__disclosure prompt-runner__disclosure--tool"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span className="prompt-runner__tool-name">⚙ {name}</span>
+        <span className="prompt-runner__tool-summary">{summary}</span>
+      </button>
+      {expanded && <pre className="prompt-runner__pre">{raw}</pre>}
+    </div>
+  );
+});
+ToolUseBlock.displayName = "ToolUseBlock";
+
+const ToolResultBlock = React.memo<{
+  content: unknown;
+  isError: boolean;
+}>(({ content, isError }) => {
+  const [expanded, setExpanded] = useState(false);
+  const text = useMemo(() => stringifyToolResult(content), [content]);
+  const shown = useMemo(() => text.slice(0, TOOL_RESULT_MAX_LENGTH), [text]);
+  const truncated = text.length > TOOL_RESULT_MAX_LENGTH;
+
+  return (
+    <div
+      className={`prompt-runner__tool-result${
+        isError ? " prompt-runner__tool-result--error" : ""
+      }`}
+    >
+      <button
+        type="button"
+        className="prompt-runner__disclosure"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span aria-hidden="true">{expanded ? "▾" : "▸"}</span>{" "}
+        {isError ? "ツール結果（エラー）" : "ツール結果"}
+      </button>
+      {expanded && (
+        <>
+          <pre className="prompt-runner__pre">{shown}</pre>
+          {truncated && (
+            <p className="prompt-runner__truncated-note">
+              （長いため先頭 {TOOL_RESULT_MAX_LENGTH} 文字のみ表示）
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+});
+ToolResultBlock.displayName = "ToolResultBlock";
+
+const ResultSummary = React.memo<{
+  durationMs?: number;
+  numTurns?: number;
+  costUsd?: number;
+  isError?: boolean;
+}>(({ durationMs, numTurns, costUsd, isError }) => {
+  const chips = useMemo(() => {
+    const items: string[] = [];
+    if (typeof durationMs === "number") {
+      items.push(`所要 ${(durationMs / 1000).toFixed(1)}s`);
+    }
+    if (typeof numTurns === "number") {
+      items.push(`${numTurns} turns`);
+    }
+    if (typeof costUsd === "number") {
+      items.push(`$${costUsd.toFixed(4)}`);
+    }
+    return items;
+  }, [durationMs, numTurns, costUsd]);
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      className={`prompt-runner__result${
+        isError ? " prompt-runner__result--error" : ""
+      }`}
+    >
+      {chips.map((chip) => (
+        <span key={chip} className="prompt-runner__chip">
+          {chip}
+        </span>
+      ))}
+    </div>
+  );
+});
+ResultSummary.displayName = "ResultSummary";
+
+const LogEntryRow = React.memo<{ entry: LogEntry }>(({ entry }) => {
+  switch (entry.kind) {
+    case "prompt":
+      return (
+        <div className="prompt-runner__bubble prompt-runner__bubble--user">
+          {entry.text}
+        </div>
+      );
+    case "block": {
+      const { block } = entry;
+      switch (block.type) {
+        case "text":
+          return <MarkdownText text={block.text} />;
+        case "thinking":
+          return <ThinkingBlock text={block.thinking ?? ""} />;
+        case "tool_use":
+          return <ToolUseBlock name={block.name} input={block.input} />;
+        case "tool_result":
+          return (
+            <ToolResultBlock
+              content={block.content}
+              isError={block.is_error === true}
+            />
+          );
+        default:
+          return null;
+      }
+    }
+    case "result":
+      return (
+        <ResultSummary
+          durationMs={entry.durationMs}
+          numTurns={entry.numTurns}
+          costUsd={entry.costUsd}
+          isError={entry.isError}
+        />
+      );
+    case "error":
+      return (
+        <div className="prompt-runner__error-row" role="alert">
+          {entry.text}
+        </div>
+      );
+    case "exit":
+      return entry.success ? (
+        <div className="prompt-runner__exit">完了</div>
+      ) : (
+        <div className="prompt-runner__exit prompt-runner__exit--error">
+          異常終了
+          {typeof entry.exitCode === "number"
+            ? `（終了コード ${entry.exitCode}）`
+            : ""}
+        </div>
+      );
+    default:
+      return null;
+  }
+});
+LogEntryRow.displayName = "LogEntryRow";
+
+const StderrSection = React.memo<{ lines: string[] }>(({ lines }) => {
+  const [expanded, setExpanded] = useState(false);
+  if (lines.length === 0) return null;
+
+  return (
+    <div className="prompt-runner__stderr">
+      <button
+        type="button"
+        className="prompt-runner__disclosure"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span aria-hidden="true">{expanded ? "▾" : "▸"}</span> stderr
+        <span className="prompt-runner__badge">{lines.length}</span>
+      </button>
+      {expanded && <pre className="prompt-runner__pre">{lines.join("\n")}</pre>}
+    </div>
+  );
+});
+StderrSection.displayName = "StderrSection";
+
+// ============================================================================
+// メインコンポーネント
+// ============================================================================
+
+interface PromptRunnerProps {
+  projectPath: string;
+  onRunFinished?: () => void;
+}
+
+export const PromptRunner: React.FC<PromptRunnerProps> = ({
+  projectPath,
+  onRunFinished,
+}) => {
+  const [cliStatus, setCliStatus] = useState<ClaudeCliStatus | null>(null);
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [stderrLines, setStderrLines] = useState<string[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [promptText, setPromptText] = useState("");
+  const [permissionMode, setPermissionMode] = useState<PermissionMode>("plan");
+  const [model, setModel] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  // イベントハンドラを張り替えないための ref 群
+  const runIdRef = useRef<string | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const onRunFinishedRef = useRef(onRunFinished);
+  const logRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  /**
+   * 送信してから startPromptRun が resolve するまでの間は run_id が未確定。
+   * その間に届いたイベントは捨てずにバッファへ積む。
+   */
+  const pendingRef = useRef(false);
+  const eventBufferRef = useRef<Map<string, PromptRunEvent[]>>(new Map());
+  const bufferedCountRef = useRef(0);
+
+  useEffect(() => {
+    onRunFinishedRef.current = onRunFinished;
+  }, [onRunFinished]);
+
+  // --- CLI ステータス取得 -----------------------------------------------
+  useEffect(() => {
+    let alive = true;
+    api
+      .getClaudeCliStatus()
+      .then((status) => {
+        if (alive) setCliStatus(status);
+      })
+      .catch((error: unknown) => {
+        if (alive) {
+          setCliStatus({ available: false, error: toErrorMessage(error) });
+        }
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // --- イベント処理（run_id の照合は呼び出し側の責務） --------------------
+  const applyEvent = useCallback((event: PromptRunEvent) => {
+    switch (event.kind) {
+      case "message": {
+        const payload = event.payload;
+        if (!payload) return;
+
+        if (payload.session_id) {
+          sessionIdRef.current = payload.session_id;
+          setSessionId(payload.session_id);
+        }
+
+        if (payload.type === "assistant" || payload.type === "user") {
+          const role = payload.type;
+          const content = payload.message?.content;
+          const blocks: StreamContentBlock[] = Array.isArray(content)
+            ? content
+            : typeof content === "string" && content.length > 0
+              ? [{ type: "text", text: content }]
+              : [];
+
+          // user メッセージはプロンプトのエコーになるため tool_result のみ表示
+          const visible =
+            role === "user"
+              ? blocks.filter((block) => block.type === "tool_result")
+              : blocks;
+          if (visible.length === 0) return;
+
+          setEntries((prev) => [
+            ...prev,
+            ...visible.map<LogEntry>((block) => ({
+              id: nextEntryId(),
+              kind: "block",
+              role,
+              block,
+            })),
+          ]);
+        } else if (payload.type === "result") {
+          setEntries((prev) => [
+            ...prev,
+            {
+              id: nextEntryId(),
+              kind: "result",
+              durationMs: payload.duration_ms,
+              numTurns: payload.num_turns,
+              costUsd: payload.total_cost_usd,
+              isError: payload.is_error,
+            },
+          ]);
+        }
+        return;
+      }
+      case "stderr": {
+        const text = event.text;
+        if (!text) return;
+        setStderrLines((prev) => [...prev, text]);
+        return;
+      }
+      case "error": {
+        setEntries((prev) => [
+          ...prev,
+          {
+            id: nextEntryId(),
+            kind: "error",
+            text: event.text ?? "不明なエラーが発生しました",
+          },
+        ]);
+        return;
+      }
+      case "exit": {
+        runIdRef.current = null;
+        setIsRunning(false);
+        setEntries((prev) => [
+          ...prev,
+          {
+            id: nextEntryId(),
+            kind: "exit",
+            success: event.success === true,
+            exitCode: event.exit_code ?? undefined,
+          },
+        ]);
+        onRunFinishedRef.current?.();
+        return;
+      }
+      default:
+        return;
+    }
+  }, []);
+
+  // --- run_id 未確定中のイベントバッファ ---------------------------------
+
+  const clearEventBuffer = useCallback(() => {
+    eventBufferRef.current.clear();
+    bufferedCountRef.current = 0;
+  }, []);
+
+  /** pending 中に届いたイベントを run_id ごとに受信順で積む */
+  const bufferEvent = useCallback((event: PromptRunEvent) => {
+    const buffer = eventBufferRef.current;
+    const queued = buffer.get(event.run_id);
+    if (queued) {
+      queued.push(event);
+    } else {
+      buffer.set(event.run_id, [event]);
+    }
+    bufferedCountRef.current += 1;
+
+    // 上限超過分は古いものから捨てる（Map は挿入順を保つ）
+    while (bufferedCountRef.current > BUFFERED_EVENT_LIMIT) {
+      const oldestRunId: string | undefined = buffer.keys().next().value;
+      if (oldestRunId === undefined) {
+        bufferedCountRef.current = 0;
+        break;
+      }
+      const oldest = buffer.get(oldestRunId);
+      if (!oldest || oldest.length === 0) {
+        buffer.delete(oldestRunId);
+        continue;
+      }
+      oldest.shift();
+      bufferedCountRef.current -= 1;
+      if (oldest.length === 0) {
+        buffer.delete(oldestRunId);
+      }
+    }
+  }, []);
+
+  /**
+   * run_id 確定直後に呼ぶ。該当 run_id のバッファを受信順どおりに流し、
+   * バッファ全体をクリアする（二重処理・リークの防止）。
+   */
+  const flushEventBuffer = useCallback(
+    (runId: string) => {
+      const buffered = eventBufferRef.current.get(runId) ?? [];
+      clearEventBuffer();
+      for (const event of buffered) {
+        applyEvent(event);
+      }
+    },
+    [applyEvent, clearEventBuffer],
+  );
+
+  // --- イベント購読（マウント時に一度だけ） ------------------------------
+  const handleEvent = useCallback(
+    (event: PromptRunEvent) => {
+      const currentRunId = runIdRef.current;
+      if (currentRunId !== null) {
+        // run_id 確定済み: 一致するものだけ処理する
+        if (event.run_id === currentRunId) {
+          applyEvent(event);
+        }
+        return;
+      }
+      // run_id 未確定かつ実行開始待ち: 捨てずにバッファへ
+      if (pendingRef.current) {
+        bufferEvent(event);
+      }
+      // どちらでもなければ無視
+    },
+    [applyEvent, bufferEvent],
+  );
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+
+    api
+      .onPromptRunEvent(handleEvent)
+      .then((fn) => {
+        if (disposed) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to subscribe prompt-run-event:", error);
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [handleEvent]);
+
+  // --- 自動スクロール（最下部付近にいるときだけ追従） --------------------
+  const handleLogScroll = useCallback(() => {
+    const el = logRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distance <= STICK_TO_BOTTOM_THRESHOLD;
+  }, []);
+
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el || !stickToBottomRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [entries, stderrLines, isRunning]);
+
+  // --- 実行 --------------------------------------------------------------
+  const cliAvailable = cliStatus?.available === true;
+  const canSend = cliAvailable && !isRunning && promptText.trim().length > 0;
+
+  const runPrompt = useCallback(async () => {
+    const text = promptText.trim();
+    if (!text) return;
+
+    setEntries((prev) => [
+      ...prev,
+      { id: nextEntryId(), kind: "prompt", text },
+    ]);
+    setPromptText("");
+    setStderrLines([]);
+    setIsRunning(true);
+    stickToBottomRef.current = true;
+
+    // run_id が返るまでのイベントを取りこぼさないよう pending に入る
+    runIdRef.current = null;
+    clearEventBuffer();
+    pendingRef.current = true;
+
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+
+    try {
+      const runId = await api.startPromptRun({
+        projectPath,
+        prompt: text,
+        permissionMode,
+        resumeSessionId: sessionIdRef.current,
+        model: model === "" ? null : model,
+      });
+      // runIdRef の設定とフラッシュの間に await を挟まないこと（順序保証）
+      runIdRef.current = runId;
+      pendingRef.current = false;
+      flushEventBuffer(runId);
+    } catch (error: unknown) {
+      runIdRef.current = null;
+      pendingRef.current = false;
+      clearEventBuffer();
+      setIsRunning(false);
+      setEntries((prev) => [
+        ...prev,
+        {
+          id: nextEntryId(),
+          kind: "error",
+          text: `実行を開始できませんでした: ${toErrorMessage(error)}`,
+        },
+      ]);
+    }
+  }, [
+    promptText,
+    projectPath,
+    permissionMode,
+    model,
+    clearEventBuffer,
+    flushEventBuffer,
+  ]);
+
+  const handleSubmit = useCallback(() => {
+    if (!canSend) return;
+    if (permissionMode === "bypassPermissions") {
+      setConfirmOpen(true);
+      return;
+    }
+    void runPrompt();
+  }, [canSend, permissionMode, runPrompt]);
+
+  const handleConfirm = useCallback(() => {
+    setConfirmOpen(false);
+    void runPrompt();
+  }, [runPrompt]);
+
+  const handleCancelConfirm = useCallback(() => {
+    setConfirmOpen(false);
+  }, []);
+
+  const handleStop = useCallback(async () => {
+    const runId = runIdRef.current;
+    if (!runId) return;
+    try {
+      await api.stopPromptRun(runId);
+    } catch (error: unknown) {
+      setEntries((prev) => [
+        ...prev,
+        {
+          id: nextEntryId(),
+          kind: "error",
+          text: `停止に失敗しました: ${toErrorMessage(error)}`,
+        },
+      ]);
+    }
+  }, []);
+
+  const handleNewConversation = useCallback(() => {
+    sessionIdRef.current = null;
+    setSessionId(null);
+    setEntries([]);
+    setStderrLines([]);
+    clearEventBuffer();
+  }, [clearEventBuffer]);
+
+  const handlePromptChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setPromptText(event.target.value);
+      const el = event.target;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, 192)}px`;
+    },
+    [],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const handlePermissionModeChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setPermissionMode(event.target.value as PermissionMode);
+    },
+    [],
+  );
+
+  const handleModelChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setModel(event.target.value);
+    },
+    [],
+  );
+
+  return (
+    <div className="prompt-runner">
+      {/* CLI ステータス */}
+      {cliStatus && !cliStatus.available && (
+        <div className="prompt-runner__banner" role="alert">
+          <span className="prompt-runner__banner-icon" aria-hidden="true">
+            ⚠️
+          </span>
+          <span>
+            {cliStatus.error ?? "claude CLI が見つかりませんでした。"}
+          </span>
+        </div>
+      )}
+      {cliAvailable && (
+        <div className="prompt-runner__cli-status">
+          claude {cliStatus?.version ?? ""}
+        </div>
+      )}
+
+      {/* 会話エリア */}
+      <div
+        className="prompt-runner__log"
+        ref={logRef}
+        onScroll={handleLogScroll}
+        role="log"
+        aria-live="polite"
+        aria-label="Claude との会話"
+      >
+        {entries.length === 0 && !isRunning && (
+          <p className="prompt-runner__placeholder">
+            まだ実行していません。下の入力欄から Claude に指示を出してください。
+          </p>
+        )}
+        {entries.map((entry) => (
+          <LogEntryRow key={entry.id} entry={entry} />
+        ))}
+        <StderrSection lines={stderrLines} />
+        {isRunning && (
+          <div className="prompt-runner__running">
+            <span className="prompt-runner__spinner" aria-hidden="true" />
+            <span>実行中…</span>
+          </div>
+        )}
+      </div>
+
+      {/* コンポーザー */}
+      <div className="prompt-runner__composer">
+        {sessionId && (
+          <div className="prompt-runner__session">
+            <span className="prompt-runner__session-label">
+              セッション継続中: {sessionId.substring(0, 8)}
+            </span>
+            <button
+              type="button"
+              className="prompt-runner__link-button"
+              onClick={handleNewConversation}
+            >
+              新しい会話
+            </button>
+          </div>
+        )}
+
+        <label className="sr-only" htmlFor="prompt-runner-input">
+          Claude への指示
+        </label>
+        <textarea
+          id="prompt-runner-input"
+          ref={textareaRef}
+          className="prompt-runner__textarea"
+          value={promptText}
+          onChange={handlePromptChange}
+          onKeyDown={handleKeyDown}
+          placeholder="Claude への指示を入力…（Cmd/Ctrl + Enter で送信）"
+          rows={3}
+        />
+
+        <div className="prompt-runner__controls">
+          <div className="prompt-runner__field">
+            <label htmlFor="prompt-runner-permission">権限モード</label>
+            <select
+              id="prompt-runner-permission"
+              value={permissionMode}
+              onChange={handlePermissionModeChange}
+              disabled={isRunning}
+            >
+              {PERMISSION_MODE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="prompt-runner__field">
+            <label htmlFor="prompt-runner-model">モデル</label>
+            <select
+              id="prompt-runner-model"
+              value={model}
+              onChange={handleModelChange}
+              disabled={isRunning}
+            >
+              {MODEL_OPTIONS.map((option) => (
+                <option key={option.value || "default"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="prompt-runner__actions">
+            {isRunning && (
+              <button
+                type="button"
+                className="prompt-runner__button prompt-runner__button--secondary"
+                onClick={() => {
+                  void handleStop();
+                }}
+              >
+                停止
+              </button>
+            )}
+            <button
+              type="button"
+              className="prompt-runner__button prompt-runner__button--primary"
+              onClick={handleSubmit}
+              disabled={!canSend}
+            >
+              送信
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <SafeConfirmDialog
+        isOpen={confirmOpen}
+        title="全許可モードで実行しますか？"
+        message="「全許可（危険）」は Claude のすべてのツール実行を確認なしで許可します。ファイルの変更やコマンド実行が無条件に行われます。本当に実行しますか？"
+        confirmText="実行する"
+        cancelText="キャンセル"
+        variant="danger"
+        onConfirm={handleConfirm}
+        onCancel={handleCancelConfirm}
+      />
+    </div>
+  );
+};

--- a/src/components/PromptRunner.tsx
+++ b/src/components/PromptRunner.tsx
@@ -2,6 +2,10 @@
  * PromptRunner — アプリ内から `claude` CLI をヘッドレス起動し、
  * stream-json 出力をリアルタイム表示するコンポーネント。
  *
+ * 会話ログ・実行状態は PromptRunsContext がプロジェクト単位で保持しており、
+ * このコンポーネントはその表示と入力 UI だけを担う。そのため Dashboard 等へ
+ * 移動してアンマウントされても会話は失われず、戻れば続きが表示される。
+ *
  * SECURITY: assistant の markdown は marked でレンダリングした後、
  * 必ず DOMPurify.sanitize() を通してから dangerouslySetInnerHTML に渡す。
  * CLI 出力は外部由来の信頼できない入力とみなす。
@@ -17,13 +21,12 @@ import React, {
   useState,
 } from "react";
 import { api } from "../api";
-import { usePromptRunsOptional } from "../contexts/PromptRunsContext";
-import type {
-  ClaudeCliStatus,
-  PermissionMode,
-  PromptRunEvent,
-  StreamContentBlock,
-} from "../types";
+import {
+  EMPTY_CONVERSATION,
+  usePromptRuns,
+  type ConversationEntry,
+} from "../contexts/PromptRunsContext";
+import type { ClaudeCliStatus, PermissionMode } from "../types";
 import { SafeConfirmDialog } from "./SafeConfirmDialog";
 
 // ============================================================================
@@ -48,12 +51,6 @@ const TOOL_RESULT_MAX_LENGTH = 4000;
 /** 自動スクロールを追従させる下端からの距離(px) */
 const STICK_TO_BOTTOM_THRESHOLD = 80;
 
-/**
- * run_id 確定前に届いたイベントを溜めるバッファの上限。
- * 超えた分は古いものから捨てる（メモリリーク防止）。
- */
-const BUFFERED_EVENT_LIMIT = 500;
-
 const PERMISSION_MODE_OPTIONS: ReadonlyArray<{
   value: PermissionMode;
   label: string;
@@ -69,35 +66,6 @@ const MODEL_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
   { value: "sonnet", label: "sonnet" },
   { value: "haiku", label: "haiku" },
 ];
-
-// ============================================================================
-// 会話ログのエントリ型
-// ============================================================================
-
-type LogEntry =
-  | { id: string; kind: "prompt"; text: string }
-  | {
-      id: string;
-      kind: "block";
-      role: "assistant" | "user";
-      block: StreamContentBlock;
-    }
-  | {
-      id: string;
-      kind: "result";
-      durationMs?: number;
-      numTurns?: number;
-      costUsd?: number;
-      isError?: boolean;
-    }
-  | { id: string; kind: "error"; text: string }
-  | { id: string; kind: "exit"; success: boolean; exitCode?: number };
-
-let entrySeq = 0;
-const nextEntryId = (): string => {
-  entrySeq += 1;
-  return `prompt-entry-${entrySeq}`;
-};
 
 // ============================================================================
 // ユーティリティ（副作用なしの純粋関数：テストしやすさのため外出し）
@@ -290,7 +258,7 @@ const ResultSummary = React.memo<{
 });
 ResultSummary.displayName = "ResultSummary";
 
-const LogEntryRow = React.memo<{ entry: LogEntry }>(({ entry }) => {
+const LogEntryRow = React.memo<{ entry: ConversationEntry }>(({ entry }) => {
   switch (entry.kind) {
     case "prompt":
       return (
@@ -385,33 +353,23 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
   onRunFinished,
 }) => {
   const [cliStatus, setCliStatus] = useState<ClaudeCliStatus | null>(null);
-  const [entries, setEntries] = useState<LogEntry[]>([]);
-  const [stderrLines, setStderrLines] = useState<string[]>([]);
-  const [isRunning, setIsRunning] = useState(false);
   const [promptText, setPromptText] = useState("");
   const [permissionMode, setPermissionMode] = useState<PermissionMode>("plan");
   const [model, setModel] = useState("");
-  const [sessionId, setSessionId] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [stopError, setStopError] = useState<string | null>(null);
 
-  // アプリ全体の実行状況ストア（Provider 配下でない場合は null で無効化）
-  const runsStore = usePromptRunsOptional();
+  // 会話ログ・実行状態はストアがプロジェクト単位で保持している
+  const { conversations, sendPrompt, resetConversation, stopRun } =
+    usePromptRuns();
+  const conversation = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
+  const { entries, stderrLines, sessionId, isRunning, activeRunId } =
+    conversation;
 
-  // イベントハンドラを張り替えないための ref 群
-  const runIdRef = useRef<string | null>(null);
-  const sessionIdRef = useRef<string | null>(null);
   const onRunFinishedRef = useRef(onRunFinished);
   const logRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  /**
-   * 送信してから startPromptRun が resolve するまでの間は run_id が未確定。
-   * その間に届いたイベントは捨てずにバッファへ積む。
-   */
-  const pendingRef = useRef(false);
-  const eventBufferRef = useRef<Map<string, PromptRunEvent[]>>(new Map());
-  const bufferedCountRef = useRef(0);
 
   useEffect(() => {
     onRunFinishedRef.current = onRunFinished;
@@ -435,190 +393,14 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
     };
   }, []);
 
-  // --- イベント処理（run_id の照合は呼び出し側の責務） --------------------
-  const applyEvent = useCallback((event: PromptRunEvent) => {
-    switch (event.kind) {
-      case "message": {
-        const payload = event.payload;
-        if (!payload) return;
-
-        if (payload.session_id) {
-          sessionIdRef.current = payload.session_id;
-          setSessionId(payload.session_id);
-        }
-
-        if (payload.type === "assistant" || payload.type === "user") {
-          const role = payload.type;
-          const content = payload.message?.content;
-          const blocks: StreamContentBlock[] = Array.isArray(content)
-            ? content
-            : typeof content === "string" && content.length > 0
-              ? [{ type: "text", text: content }]
-              : [];
-
-          // user メッセージはプロンプトのエコーになるため tool_result のみ表示
-          const visible =
-            role === "user"
-              ? blocks.filter((block) => block.type === "tool_result")
-              : blocks;
-          if (visible.length === 0) return;
-
-          setEntries((prev) => [
-            ...prev,
-            ...visible.map<LogEntry>((block) => ({
-              id: nextEntryId(),
-              kind: "block",
-              role,
-              block,
-            })),
-          ]);
-        } else if (payload.type === "result") {
-          setEntries((prev) => [
-            ...prev,
-            {
-              id: nextEntryId(),
-              kind: "result",
-              durationMs: payload.duration_ms,
-              numTurns: payload.num_turns,
-              costUsd: payload.total_cost_usd,
-              isError: payload.is_error,
-            },
-          ]);
-        }
-        return;
-      }
-      case "stderr": {
-        const text = event.text;
-        if (!text) return;
-        setStderrLines((prev) => [...prev, text]);
-        return;
-      }
-      case "error": {
-        setEntries((prev) => [
-          ...prev,
-          {
-            id: nextEntryId(),
-            kind: "error",
-            text: event.text ?? "不明なエラーが発生しました",
-          },
-        ]);
-        return;
-      }
-      case "exit": {
-        runIdRef.current = null;
-        setIsRunning(false);
-        setEntries((prev) => [
-          ...prev,
-          {
-            id: nextEntryId(),
-            kind: "exit",
-            success: event.success === true,
-            exitCode: event.exit_code ?? undefined,
-          },
-        ]);
-        onRunFinishedRef.current?.();
-        return;
-      }
-      default:
-        return;
-    }
-  }, []);
-
-  // --- run_id 未確定中のイベントバッファ ---------------------------------
-
-  const clearEventBuffer = useCallback(() => {
-    eventBufferRef.current.clear();
-    bufferedCountRef.current = 0;
-  }, []);
-
-  /** pending 中に届いたイベントを run_id ごとに受信順で積む */
-  const bufferEvent = useCallback((event: PromptRunEvent) => {
-    const buffer = eventBufferRef.current;
-    const queued = buffer.get(event.run_id);
-    if (queued) {
-      queued.push(event);
-    } else {
-      buffer.set(event.run_id, [event]);
-    }
-    bufferedCountRef.current += 1;
-
-    // 上限超過分は古いものから捨てる（Map は挿入順を保つ）
-    while (bufferedCountRef.current > BUFFERED_EVENT_LIMIT) {
-      const oldestRunId: string | undefined = buffer.keys().next().value;
-      if (oldestRunId === undefined) {
-        bufferedCountRef.current = 0;
-        break;
-      }
-      const oldest = buffer.get(oldestRunId);
-      if (!oldest || oldest.length === 0) {
-        buffer.delete(oldestRunId);
-        continue;
-      }
-      oldest.shift();
-      bufferedCountRef.current -= 1;
-      if (oldest.length === 0) {
-        buffer.delete(oldestRunId);
-      }
-    }
-  }, []);
-
-  /**
-   * run_id 確定直後に呼ぶ。該当 run_id のバッファを受信順どおりに流し、
-   * バッファ全体をクリアする（二重処理・リークの防止）。
-   */
-  const flushEventBuffer = useCallback(
-    (runId: string) => {
-      const buffered = eventBufferRef.current.get(runId) ?? [];
-      clearEventBuffer();
-      for (const event of buffered) {
-        applyEvent(event);
-      }
-    },
-    [applyEvent, clearEventBuffer],
-  );
-
-  // --- イベント購読（マウント時に一度だけ） ------------------------------
-  const handleEvent = useCallback(
-    (event: PromptRunEvent) => {
-      const currentRunId = runIdRef.current;
-      if (currentRunId !== null) {
-        // run_id 確定済み: 一致するものだけ処理する
-        if (event.run_id === currentRunId) {
-          applyEvent(event);
-        }
-        return;
-      }
-      // run_id 未確定かつ実行開始待ち: 捨てずにバッファへ
-      if (pendingRef.current) {
-        bufferEvent(event);
-      }
-      // どちらでもなければ無視
-    },
-    [applyEvent, bufferEvent],
-  );
-
+  // --- 実行完了の検知（isRunning の true → false 遷移で通知） -------------
+  const prevRunningRef = useRef(isRunning);
   useEffect(() => {
-    let disposed = false;
-    let unlisten: (() => void) | undefined;
-
-    api
-      .onPromptRunEvent(handleEvent)
-      .then((fn) => {
-        if (disposed) {
-          fn();
-        } else {
-          unlisten = fn;
-        }
-      })
-      .catch((error: unknown) => {
-        console.error("Failed to subscribe prompt-run-event:", error);
-      });
-
-    return () => {
-      disposed = true;
-      unlisten?.();
-    };
-  }, [handleEvent]);
+    if (prevRunningRef.current && !isRunning) {
+      onRunFinishedRef.current?.();
+    }
+    prevRunningRef.current = isRunning;
+  }, [isRunning]);
 
   // --- 自動スクロール（最下部付近にいるときだけ追従） --------------------
   const handleLogScroll = useCallback(() => {
@@ -642,66 +424,19 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
     const text = promptText.trim();
     if (!text) return;
 
-    setEntries((prev) => [
-      ...prev,
-      { id: nextEntryId(), kind: "prompt", text },
-    ]);
     setPromptText("");
-    setStderrLines([]);
-    setIsRunning(true);
+    setStopError(null);
     stickToBottomRef.current = true;
-
-    // run_id が返るまでのイベントを取りこぼさないよう pending に入る
-    runIdRef.current = null;
-    clearEventBuffer();
-    pendingRef.current = true;
-
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
 
-    try {
-      const runId = await api.startPromptRun({
-        projectPath,
-        prompt: text,
-        permissionMode,
-        resumeSessionId: sessionIdRef.current,
-        model: model === "" ? null : model,
-      });
-      // runIdRef の設定とフラッシュの間に await を挟まないこと（順序保証）
-      runIdRef.current = runId;
-      pendingRef.current = false;
-      flushEventBuffer(runId);
-      // アプリ全体の実行状況ストアにも登録する（Prompts タブ / Dashboard 用）
-      runsStore?.registerRun(runId, {
-        projectPath,
-        prompt: text,
-        permissionMode,
-        model: model === "" ? null : model,
-      });
-    } catch (error: unknown) {
-      runIdRef.current = null;
-      pendingRef.current = false;
-      clearEventBuffer();
-      setIsRunning(false);
-      setEntries((prev) => [
-        ...prev,
-        {
-          id: nextEntryId(),
-          kind: "error",
-          text: `実行を開始できませんでした: ${toErrorMessage(error)}`,
-        },
-      ]);
-    }
-  }, [
-    promptText,
-    projectPath,
-    permissionMode,
-    model,
-    clearEventBuffer,
-    flushEventBuffer,
-    runsStore,
-  ]);
+    await sendPrompt(projectPath, {
+      prompt: text,
+      permissionMode,
+      model: model === "" ? null : model,
+    });
+  }, [promptText, projectPath, permissionMode, model, sendPrompt]);
 
   const handleSubmit = useCallback(() => {
     if (!canSend) return;
@@ -722,29 +457,17 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
   }, []);
 
   const handleStop = useCallback(async () => {
-    const runId = runIdRef.current;
-    if (!runId) return;
+    if (!activeRunId) return;
     try {
-      await api.stopPromptRun(runId);
+      await stopRun(activeRunId);
     } catch (error: unknown) {
-      setEntries((prev) => [
-        ...prev,
-        {
-          id: nextEntryId(),
-          kind: "error",
-          text: `停止に失敗しました: ${toErrorMessage(error)}`,
-        },
-      ]);
+      setStopError(`停止に失敗しました: ${toErrorMessage(error)}`);
     }
-  }, []);
+  }, [activeRunId, stopRun]);
 
   const handleNewConversation = useCallback(() => {
-    sessionIdRef.current = null;
-    setSessionId(null);
-    setEntries([]);
-    setStderrLines([]);
-    clearEventBuffer();
-  }, [clearEventBuffer]);
+    resetConversation(projectPath);
+  }, [resetConversation, projectPath]);
 
   const handlePromptChange = useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -817,6 +540,11 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
           <LogEntryRow key={entry.id} entry={entry} />
         ))}
         <StderrSection lines={stderrLines} />
+        {stopError && (
+          <div className="prompt-runner__error-row" role="alert">
+            {stopError}
+          </div>
+        )}
         {isRunning && (
           <div className="prompt-runner__running">
             <span className="prompt-runner__spinner" aria-hidden="true" />

--- a/src/components/PromptsOverview.tsx
+++ b/src/components/PromptsOverview.tsx
@@ -1,0 +1,194 @@
+/**
+ * 全プロジェクトのプロンプト実行状況を一覧するビュー（ナビの Prompts タブ）。
+ *
+ * データは PromptRunsContext から取得する。ここからは各プロジェクトの
+ * Prompt タブへジャンプでき、実行中のランはその場で停止できる。
+ */
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  formatElapsed,
+  RUN_STATUS_META,
+  usePromptRuns,
+  type PromptRunInfo,
+  type PromptRunStatus,
+} from "../contexts/PromptRunsContext";
+import { getProjectDisplayName } from "../utils/pathUtils";
+
+interface PromptsOverviewProps {
+  onOpenProject: (projectPath: string) => void;
+}
+
+type Filter = "all" | PromptRunStatus;
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: "all", label: "すべて" },
+  { key: "running", label: "実行中" },
+  { key: "completed", label: "完了" },
+  { key: "failed", label: "失敗" },
+  { key: "stopped", label: "停止" },
+];
+
+const RunRow: React.FC<{
+  run: PromptRunInfo;
+  now: number;
+  onOpen: () => void;
+  onStop: () => void;
+}> = ({ run, now, onOpen, onStop }) => {
+  const meta = RUN_STATUS_META[run.status];
+  const elapsed =
+    run.status === "running"
+      ? formatElapsed(now - run.startedAt)
+      : run.durationMs !== null
+        ? formatElapsed(run.durationMs)
+        : null;
+
+  return (
+    <li className={`prompt-runs-row prompt-runs-row--${run.status}`}>
+      <span
+        className={`prompt-runs-row__icon prompt-runs-row__icon--${run.status}`}
+        role="img"
+        aria-label={meta.label}
+      >
+        {meta.icon}
+      </span>
+      <div className="prompt-runs-row__body">
+        <div className="prompt-runs-row__title">
+          <span className="prompt-runs-row__project">
+            {getProjectDisplayName(run.projectPath)}
+          </span>
+          <span className="prompt-runs-row__meta">
+            {elapsed && <span>{elapsed}</span>}
+            {run.numTurns !== null && <span>{run.numTurns} turns</span>}
+            {run.costUsd !== null && <span>${run.costUsd.toFixed(4)}</span>}
+            {run.status === "failed" && run.exitCode !== null && (
+              <span>終了コード {run.exitCode}</span>
+            )}
+          </span>
+        </div>
+        <div className="prompt-runs-row__prompt" title={run.prompt}>
+          {run.prompt}
+        </div>
+        {run.status === "running" && run.lastActivity && (
+          <div className="prompt-runs-row__activity">{run.lastActivity}</div>
+        )}
+      </div>
+      <div className="prompt-runs-row__actions">
+        {run.status === "running" && (
+          <button
+            type="button"
+            className="prompt-runs-row__button"
+            onClick={onStop}
+          >
+            停止
+          </button>
+        )}
+        <button
+          type="button"
+          className="prompt-runs-row__button prompt-runs-row__button--primary"
+          onClick={onOpen}
+        >
+          開く
+        </button>
+      </div>
+    </li>
+  );
+};
+
+export const PromptsOverview: React.FC<PromptsOverviewProps> = ({
+  onOpenProject,
+}) => {
+  const { runs, runningCount, stopRun } = usePromptRuns();
+  const [filter, setFilter] = useState<Filter>("all");
+  const [now, setNow] = useState(() => Date.now());
+
+  // 実行中の経過時間表示のため 1 秒ごとに now を更新する
+  const hasRunning = runningCount > 0;
+  useEffect(() => {
+    if (!hasRunning) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [hasRunning]);
+
+  const counts = useMemo(() => {
+    const c: Record<Filter, number> = {
+      all: runs.length,
+      running: 0,
+      completed: 0,
+      failed: 0,
+      stopped: 0,
+    };
+    for (const run of runs) c[run.status] += 1;
+    return c;
+  }, [runs]);
+
+  const visibleRuns = useMemo(
+    () => (filter === "all" ? runs : runs.filter((r) => r.status === filter)),
+    [runs, filter],
+  );
+
+  const handleStop = useCallback(
+    (runId: string) => {
+      stopRun(runId).catch((error: unknown) => {
+        console.error("Failed to stop prompt run:", error);
+      });
+    },
+    [stopRun],
+  );
+
+  return (
+    <div className="prompts-overview">
+      <header className="prompts-overview__header">
+        <h2 className="prompts-overview__title">Prompts</h2>
+        <p className="prompts-overview__subtitle">
+          全プロジェクトのプロンプト実行状況（アプリ起動中の履歴）
+        </p>
+      </header>
+
+      <div
+        className="prompts-overview__filters"
+        role="group"
+        aria-label="実行状態で絞り込み"
+      >
+        {FILTERS.map(({ key, label }) => (
+          <button
+            key={key}
+            type="button"
+            className={`prompts-overview__filter ${
+              filter === key ? "prompts-overview__filter--active" : ""
+            }`}
+            aria-pressed={filter === key}
+            onClick={() => setFilter(key)}
+          >
+            {key !== "all" && (
+              <span aria-hidden="true">{RUN_STATUS_META[key].icon} </span>
+            )}
+            {label}
+            <span className="prompts-overview__filter-count">
+              {counts[key]}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {visibleRuns.length === 0 ? (
+        <div className="prompts-overview__empty">
+          {runs.length === 0
+            ? "まだプロンプトを実行していません。プロジェクトを開き、Prompt タブから Claude に指示を出せます。"
+            : "この条件に一致する実行はありません。"}
+        </div>
+      ) : (
+        <ul className="prompts-overview__list">
+          {visibleRuns.map((run) => (
+            <RunRow
+              key={run.runId}
+              run={run}
+              now={now}
+              onOpen={() => onOpenProject(run.projectPath)}
+              onStop={() => handleStop(run.runId)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/components/__tests__/PromptRunner.test.tsx
+++ b/src/components/__tests__/PromptRunner.test.tsx
@@ -1,0 +1,454 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { PromptRunner } from "../PromptRunner";
+import { api } from "../../api";
+import type { PromptRunEvent } from "../../types";
+
+vi.mock("../../api");
+const mockApi = vi.mocked(api);
+
+const RUN_ID = "run-1";
+
+/** api.onPromptRunEvent に登録されたハンドラ（テストから疑似イベントを流す） */
+let emit: ((event: PromptRunEvent) => void) | null = null;
+
+/** マイクロタスクを flush して startPromptRun の解決を待つ */
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+const typePrompt = (value: string): void => {
+  const textarea = screen.getByLabelText("Claude への指示");
+  fireEvent.change(textarea, { target: { value } });
+};
+
+const getSendButton = (): HTMLButtonElement =>
+  screen.getByRole("button", { name: "送信" }) as HTMLButtonElement;
+
+describe("PromptRunner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emit = null;
+
+    mockApi.getClaudeCliStatus.mockResolvedValue({
+      available: true,
+      path: "/usr/local/bin/claude",
+      version: "2.1.226 (Claude Code)",
+    });
+    mockApi.startPromptRun.mockResolvedValue(RUN_ID);
+    mockApi.stopPromptRun.mockResolvedValue(undefined);
+    mockApi.onPromptRunEvent.mockImplementation(async (handler) => {
+      emit = handler;
+      return () => {
+        emit = null;
+      };
+    });
+  });
+
+  it("should render the composer when the CLI is available", async () => {
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("claude 2.1.226 (Claude Code)"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText("Claude への指示")).toBeInTheDocument();
+    expect(screen.getByLabelText("権限モード")).toBeInTheDocument();
+    expect(screen.getByLabelText("モデル")).toBeInTheDocument();
+    expect(getSendButton()).toBeInTheDocument();
+  });
+
+  it("should disable the send button while the prompt is empty", async () => {
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(getSendButton()).toBeDisabled();
+    });
+
+    typePrompt("テストのプロンプト");
+    expect(getSendButton()).toBeEnabled();
+
+    // 空白のみは送信不可
+    typePrompt("   ");
+    expect(getSendButton()).toBeDisabled();
+  });
+
+  it("should call startPromptRun with the expected arguments", async () => {
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(getSendButton()).toBeInTheDocument();
+    });
+
+    typePrompt("README を要約して");
+    fireEvent.click(getSendButton());
+
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledWith({
+        projectPath: "/Users/john/projects/demo",
+        prompt: "README を要約して",
+        permissionMode: "plan",
+        resumeSessionId: null,
+        model: null,
+      });
+    });
+
+    expect(screen.getByText("README を要約して")).toBeInTheDocument();
+    expect(screen.getByText("実行中…")).toBeInTheDocument();
+  });
+
+  it("should render assistant text received through onPromptRunEvent", async () => {
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
+    });
+
+    typePrompt("こんにちは");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+    await flush();
+
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          session_id: "aaaabbbb-cccc-dddd-eeee-ffff00001111",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "こんにちは、手伝います。" }],
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("こんにちは、手伝います。")).toBeInTheDocument();
+    });
+
+    // session_id を保持して継続表示になる
+    expect(screen.getByText("セッション継続中: aaaabbbb")).toBeInTheDocument();
+  });
+
+  it("should buffer events that arrive before startPromptRun resolves", async () => {
+    // startPromptRun の resolve を意図的に遅延させ、run_id 確定前にイベントを流す
+    let resolveStart: ((runId: string) => void) | null = null;
+    mockApi.startPromptRun.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+
+    const onRunFinished = vi.fn();
+    render(
+      <PromptRunner
+        projectPath="/Users/john/projects/demo"
+        onRunFinished={onRunFinished}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
+    });
+
+    typePrompt("即座に終わる処理");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+
+    // run_id 未確定（pending）の間に、起動直後に即死したプロセスを模して流す
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          session_id: "99998888-7777-6666-5555-444433332222",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "バッファされた最初の出力" }],
+          },
+        },
+      });
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "バッファされた次の出力" }],
+          },
+        },
+      });
+      emit?.({
+        run_id: RUN_ID,
+        kind: "exit",
+        exit_code: 1,
+        success: false,
+      });
+    });
+
+    // まだ resolve していないので反映されず、実行中のまま
+    expect(
+      screen.queryByText("バッファされた最初の出力"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("実行中…")).toBeInTheDocument();
+    expect(onRunFinished).not.toHaveBeenCalled();
+
+    // run_id が確定するとバッファが受信順どおりにフラッシュされる
+    await act(async () => {
+      resolveStart?.(RUN_ID);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("バッファされた最初の出力")).toBeInTheDocument();
+    });
+
+    const log = screen.getByRole("log");
+    const rendered = Array.from(
+      log.querySelectorAll(".prompt-runner__markdown"),
+    ).map((el) => el.textContent?.trim());
+    expect(rendered).toEqual([
+      "バッファされた最初の出力",
+      "バッファされた次の出力",
+    ]);
+
+    // exit がバッファ経由で来ても実行中フラグは解除され onRunFinished が呼ばれる
+    expect(screen.queryByText("実行中…")).not.toBeInTheDocument();
+    expect(onRunFinished).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("異常終了（終了コード 1）")).toBeInTheDocument();
+    expect(screen.getByText("セッション継続中: 99998888")).toBeInTheDocument();
+  });
+
+  it("should not double-process buffered events after the flush", async () => {
+    let resolveStart: ((runId: string) => void) | null = null;
+    mockApi.startPromptRun.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveStart = resolve;
+        }),
+    );
+
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    await waitFor(() => expect(mockApi.onPromptRunEvent).toHaveBeenCalled());
+
+    typePrompt("重複確認");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "一度だけ出るはず" }],
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      resolveStart?.(RUN_ID);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("一度だけ出るはず")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("一度だけ出るはず")).toHaveLength(1);
+  });
+
+  it("should drop the buffer when startPromptRun rejects", async () => {
+    let rejectStart: ((error: Error) => void) | null = null;
+    mockApi.startPromptRun.mockImplementation(
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectStart = reject;
+        }),
+    );
+
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    await waitFor(() => expect(mockApi.onPromptRunEvent).toHaveBeenCalled());
+
+    typePrompt("起動に失敗する");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "捨てられるべき出力" }],
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      rejectStart?.(new Error("spawn failed"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("実行を開始できませんでした: spawn failed"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("捨てられるべき出力")).not.toBeInTheDocument();
+    expect(screen.queryByText("実行中…")).not.toBeInTheDocument();
+  });
+
+  it("should ignore mismatched run_id events once the run_id is settled", async () => {
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
+    });
+
+    typePrompt("こんにちは");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+    await flush();
+
+    act(() => {
+      emit?.({
+        run_id: "other-run",
+        kind: "message",
+        payload: {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "別の実行の出力" }],
+          },
+        },
+      });
+    });
+
+    expect(screen.queryByText("別の実行の出力")).not.toBeInTheDocument();
+  });
+
+  it("should clear the running state and call onRunFinished on exit", async () => {
+    const onRunFinished = vi.fn();
+    render(
+      <PromptRunner
+        projectPath="/Users/john/projects/demo"
+        onRunFinished={onRunFinished}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
+    });
+
+    typePrompt("ビルドして");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+    await flush();
+
+    expect(screen.getByText("実行中…")).toBeInTheDocument();
+
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "exit",
+        exit_code: 0,
+        success: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("実行中…")).not.toBeInTheDocument();
+    });
+
+    expect(onRunFinished).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("完了")).toBeInTheDocument();
+  });
+
+  it("should warn and disable sending when the CLI is unavailable", async () => {
+    mockApi.getClaudeCliStatus.mockResolvedValue({
+      available: false,
+      error: "claude コマンドが見つかりませんでした。",
+    });
+
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("claude コマンドが見つかりませんでした。"),
+      ).toBeInTheDocument();
+    });
+
+    typePrompt("何かして");
+    expect(getSendButton()).toBeDisabled();
+    expect(mockApi.startPromptRun).not.toHaveBeenCalled();
+  });
+
+  it("should show an error row when startPromptRun rejects", async () => {
+    mockApi.startPromptRun.mockRejectedValue(new Error("spawn failed"));
+
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(getSendButton()).toBeInTheDocument();
+    });
+
+    typePrompt("実行して");
+    fireEvent.click(getSendButton());
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("実行を開始できませんでした: spawn failed"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("実行中…")).not.toBeInTheDocument();
+  });
+
+  it("should ask for confirmation before running in bypassPermissions mode", async () => {
+    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+
+    await waitFor(() => {
+      expect(getSendButton()).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("権限モード"), {
+      target: { value: "bypassPermissions" },
+    });
+    typePrompt("危険な操作");
+    fireEvent.click(getSendButton());
+
+    expect(
+      screen.getByText("全許可モードで実行しますか？"),
+    ).toBeInTheDocument();
+    expect(mockApi.startPromptRun).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "実行する" }));
+
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledWith(
+        expect.objectContaining({ permissionMode: "bypassPermissions" }),
+      );
+    });
+  });
+});

--- a/src/components/__tests__/PromptRunner.test.tsx
+++ b/src/components/__tests__/PromptRunner.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
 import {
   render,
   screen,
@@ -7,6 +8,7 @@ import {
   act,
 } from "@testing-library/react";
 import { PromptRunner } from "../PromptRunner";
+import { PromptRunsProvider } from "../../contexts/PromptRunsContext";
 import { api } from "../../api";
 import type { PromptRunEvent } from "../../types";
 
@@ -33,6 +35,16 @@ const typePrompt = (value: string): void => {
 const getSendButton = (): HTMLButtonElement =>
   screen.getByRole("button", { name: "送信" }) as HTMLButtonElement;
 
+/** ストア（Provider）配下でレンダリングする。会話状態はストアが保持する */
+const renderRunner = (
+  props: Partial<React.ComponentProps<typeof PromptRunner>> = {},
+) =>
+  render(
+    <PromptRunsProvider>
+      <PromptRunner projectPath="/Users/john/projects/demo" {...props} />
+    </PromptRunsProvider>,
+  );
+
 describe("PromptRunner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -54,7 +66,7 @@ describe("PromptRunner", () => {
   });
 
   it("should render the composer when the CLI is available", async () => {
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(
@@ -69,7 +81,7 @@ describe("PromptRunner", () => {
   });
 
   it("should disable the send button while the prompt is empty", async () => {
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(getSendButton()).toBeDisabled();
@@ -84,7 +96,7 @@ describe("PromptRunner", () => {
   });
 
   it("should call startPromptRun with the expected arguments", async () => {
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(getSendButton()).toBeInTheDocument();
@@ -108,7 +120,7 @@ describe("PromptRunner", () => {
   });
 
   it("should render assistant text received through onPromptRunEvent", async () => {
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
@@ -153,12 +165,7 @@ describe("PromptRunner", () => {
     );
 
     const onRunFinished = vi.fn();
-    render(
-      <PromptRunner
-        projectPath="/Users/john/projects/demo"
-        onRunFinished={onRunFinished}
-      />,
-    );
+    renderRunner({ onRunFinished });
 
     await waitFor(() => {
       expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
@@ -243,7 +250,7 @@ describe("PromptRunner", () => {
         }),
     );
 
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
     await waitFor(() => expect(mockApi.onPromptRunEvent).toHaveBeenCalled());
 
     typePrompt("重複確認");
@@ -284,7 +291,7 @@ describe("PromptRunner", () => {
         }),
     );
 
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
     await waitFor(() => expect(mockApi.onPromptRunEvent).toHaveBeenCalled());
 
     typePrompt("起動に失敗する");
@@ -320,7 +327,7 @@ describe("PromptRunner", () => {
   });
 
   it("should ignore mismatched run_id events once the run_id is settled", async () => {
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
@@ -350,12 +357,7 @@ describe("PromptRunner", () => {
 
   it("should clear the running state and call onRunFinished on exit", async () => {
     const onRunFinished = vi.fn();
-    render(
-      <PromptRunner
-        projectPath="/Users/john/projects/demo"
-        onRunFinished={onRunFinished}
-      />,
-    );
+    renderRunner({ onRunFinished });
 
     await waitFor(() => {
       expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
@@ -391,7 +393,7 @@ describe("PromptRunner", () => {
       error: "claude コマンドが見つかりませんでした。",
     });
 
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(
@@ -407,7 +409,7 @@ describe("PromptRunner", () => {
   it("should show an error row when startPromptRun rejects", async () => {
     mockApi.startPromptRun.mockRejectedValue(new Error("spawn failed"));
 
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(getSendButton()).toBeInTheDocument();
@@ -426,7 +428,7 @@ describe("PromptRunner", () => {
   });
 
   it("should ask for confirmation before running in bypassPermissions mode", async () => {
-    render(<PromptRunner projectPath="/Users/john/projects/demo" />);
+    renderRunner();
 
     await waitFor(() => {
       expect(getSendButton()).toBeInTheDocument();
@@ -450,5 +452,110 @@ describe("PromptRunner", () => {
         expect.objectContaining({ permissionMode: "bypassPermissions" }),
       );
     });
+  });
+
+  it("should keep the conversation after the runner unmounts and remounts", async () => {
+    // Dashboard へ移動して戻るケースの再現:
+    // PromptRunner はアンマウントされるが Provider（ストア）は生き続ける
+    const { rerender } = render(
+      <PromptRunsProvider>
+        <PromptRunner projectPath="/Users/john/projects/demo" />
+      </PromptRunsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
+    });
+
+    typePrompt("最初のプロンプト");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+    await flush();
+
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          session_id: "aaaabbbb-cccc-dddd-eeee-ffff00001111",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "残っているべき応答" }],
+          },
+        },
+      });
+      emit?.({ run_id: RUN_ID, kind: "exit", exit_code: 0, success: true });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("残っているべき応答")).toBeInTheDocument();
+    });
+
+    // PromptRunner をアンマウント（Dashboard 表示に相当）
+    rerender(<PromptRunsProvider>{null}</PromptRunsProvider>);
+    expect(screen.queryByText("残っているべき応答")).not.toBeInTheDocument();
+
+    // アンマウント中に届いたイベントもストアには蓄積される…はここでは対象外
+    // （実行は終了済み）。再マウントで会話が復元されることを確認する
+    rerender(
+      <PromptRunsProvider>
+        <PromptRunner projectPath="/Users/john/projects/demo" />
+      </PromptRunsProvider>,
+    );
+
+    expect(screen.getByText("最初のプロンプト")).toBeInTheDocument();
+    expect(screen.getByText("残っているべき応答")).toBeInTheDocument();
+    expect(screen.getByText("完了")).toBeInTheDocument();
+    expect(screen.getByText("セッション継続中: aaaabbbb")).toBeInTheDocument();
+  });
+
+  it("should accumulate events into the store while the runner is unmounted", async () => {
+    // 実行中に Dashboard へ移動 → 実行が進む → 戻ると全部表示されている
+    const { rerender } = render(
+      <PromptRunsProvider>
+        <PromptRunner projectPath="/Users/john/projects/demo" />
+      </PromptRunsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockApi.onPromptRunEvent).toHaveBeenCalled();
+    });
+
+    typePrompt("長い処理");
+    fireEvent.click(getSendButton());
+    await waitFor(() => expect(mockApi.startPromptRun).toHaveBeenCalled());
+    await flush();
+
+    // 実行中のままアンマウント
+    rerender(<PromptRunsProvider>{null}</PromptRunsProvider>);
+
+    // 不在の間に応答と終了が届く（Provider は購読を維持している）
+    act(() => {
+      emit?.({
+        run_id: RUN_ID,
+        kind: "message",
+        payload: {
+          type: "assistant",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "不在中に届いた応答" }],
+          },
+        },
+      });
+      emit?.({ run_id: RUN_ID, kind: "exit", exit_code: 0, success: true });
+    });
+
+    // 再マウントすると不在中のイベントも含めて表示される
+    rerender(
+      <PromptRunsProvider>
+        <PromptRunner projectPath="/Users/john/projects/demo" />
+      </PromptRunsProvider>,
+    );
+
+    expect(screen.getByText("長い処理")).toBeInTheDocument();
+    expect(screen.getByText("不在中に届いた応答")).toBeInTheDocument();
+    expect(screen.getByText("完了")).toBeInTheDocument();
+    expect(screen.queryByText("実行中…")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/PromptsOverview.test.tsx
+++ b/src/components/__tests__/PromptsOverview.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import React from "react";
+import { PromptsOverview } from "../PromptsOverview";
+import {
+  PromptRunsProvider,
+  usePromptRuns,
+  type RegisterRunMeta,
+} from "../../contexts/PromptRunsContext";
+import { api } from "../../api";
+import type { PromptRunEvent } from "../../types";
+
+vi.mock("../../api");
+const mockApi = vi.mocked(api);
+
+/** api.onPromptRunEvent に登録された全ハンドラ（Provider が購読する） */
+let handlers: Set<(event: PromptRunEvent) => void> = new Set();
+
+const emit = (event: PromptRunEvent): void => {
+  act(() => {
+    for (const handler of handlers) handler(event);
+  });
+};
+
+/** Provider 配下から registerRun を呼び出すためのテスト用ハーネス */
+let registerRun: ((runId: string, meta: RegisterRunMeta) => void) | null = null;
+
+const Harness: React.FC = () => {
+  const store = usePromptRuns();
+  registerRun = store.registerRun;
+  return null;
+};
+
+const renderOverview = (onOpenProject = vi.fn()) => {
+  const result = render(
+    <PromptRunsProvider>
+      <Harness />
+      <PromptsOverview onOpenProject={onOpenProject} />
+    </PromptRunsProvider>,
+  );
+  return { ...result, onOpenProject };
+};
+
+const register = (runId: string, projectPath = "/Users/john/projects/demo") => {
+  act(() => {
+    registerRun?.(runId, {
+      projectPath,
+      prompt: "テストを追加して",
+      permissionMode: "plan",
+      model: null,
+    });
+  });
+};
+
+describe("PromptsOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = new Set();
+    registerRun = null;
+
+    mockApi.stopPromptRun.mockResolvedValue(undefined);
+    mockApi.onPromptRunEvent.mockImplementation(async (handler) => {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    });
+  });
+
+  it("実行が無いときは空状態を表示する", () => {
+    renderOverview();
+    expect(
+      screen.getByText(/まだプロンプトを実行していません/),
+    ).toBeInTheDocument();
+  });
+
+  it("登録した実行が実行中として表示される", () => {
+    renderOverview();
+    register("run-1");
+
+    expect(screen.getByText("demo")).toBeInTheDocument();
+    expect(screen.getByText("テストを追加して")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "停止" })).toBeInTheDocument();
+  });
+
+  it("exit イベントで完了に変わり停止ボタンが消える", () => {
+    renderOverview();
+    register("run-1");
+
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+
+    expect(screen.getByLabelText("完了")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "停止" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("終了コード 143 は停止として扱う", () => {
+    renderOverview();
+    register("run-1");
+
+    emit({ run_id: "run-1", kind: "exit", exit_code: 143, success: false });
+
+    expect(screen.getByLabelText("停止")).toBeInTheDocument();
+  });
+
+  it("登録前に届いたイベントも登録後に反映される", () => {
+    renderOverview();
+
+    // registerRun より先にイベントが届く（startPromptRun resolve 前のレース）
+    emit({
+      run_id: "run-1",
+      kind: "message",
+      payload: {
+        type: "assistant",
+        session_id: "sess-1",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Read",
+              input: { file_path: "src/api.ts" },
+            },
+          ],
+        },
+      },
+    });
+    emit({ run_id: "run-1", kind: "exit", exit_code: 1, success: false });
+
+    register("run-1");
+
+    // バッファされたイベントが順に適用され、失敗として表示される
+    expect(screen.getByLabelText("失敗")).toBeInTheDocument();
+    expect(screen.getByText(/終了コード 1/)).toBeInTheDocument();
+  });
+
+  it("フィルタで絞り込める", () => {
+    renderOverview();
+    register("run-1", "/Users/john/projects/alpha");
+    register("run-2", "/Users/john/projects/beta");
+    emit({ run_id: "run-2", kind: "exit", exit_code: 0, success: true });
+
+    // 完了フィルタ → beta のみ
+    fireEvent.click(screen.getByRole("button", { name: /完了/ }));
+    expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+    expect(screen.getByText("beta")).toBeInTheDocument();
+
+    // 実行中フィルタ → alpha のみ
+    fireEvent.click(screen.getByRole("button", { name: /実行中/ }));
+    expect(screen.getByText("alpha")).toBeInTheDocument();
+    expect(screen.queryByText("beta")).not.toBeInTheDocument();
+  });
+
+  it("開くで onOpenProject が呼ばれる", () => {
+    const { onOpenProject } = renderOverview();
+    register("run-1", "/Users/john/projects/alpha");
+
+    fireEvent.click(screen.getByRole("button", { name: "開く" }));
+    expect(onOpenProject).toHaveBeenCalledWith("/Users/john/projects/alpha");
+  });
+
+  it("停止で api.stopPromptRun が呼ばれる", async () => {
+    renderOverview();
+    register("run-1");
+
+    fireEvent.click(screen.getByRole("button", { name: "停止" }));
+    await waitFor(() => {
+      expect(mockApi.stopPromptRun).toHaveBeenCalledWith("run-1");
+    });
+  });
+});

--- a/src/contexts/PromptRunsContext.tsx
+++ b/src/contexts/PromptRunsContext.tsx
@@ -1,0 +1,326 @@
+/**
+ * アプリ全体でプロンプト実行の状態を共有するストア。
+ *
+ * PromptRunner（各プロジェクトの Prompt タブ）は会話の詳細表示を担い、
+ * このストアは「どのプロジェクトで何が動いていて、どう終わったか」という
+ * サマリーだけを保持する。`prompt-run-event` を独自に購読するため、
+ * PromptRunner がアンマウントされても実行状況の追跡は継続する。
+ *
+ * 履歴はメモリ上のみ（アプリを終了すると消える）。
+ */
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { api } from "../api";
+import type { PermissionMode, PromptRunEvent } from "../types";
+
+export type PromptRunStatus = "running" | "completed" | "failed" | "stopped";
+
+export interface PromptRunInfo {
+  runId: string;
+  projectPath: string;
+  prompt: string;
+  permissionMode: PermissionMode;
+  model: string | null;
+  status: PromptRunStatus;
+  startedAt: number;
+  finishedAt: number | null;
+  sessionId: string | null;
+  /** 最後に観測したアクティビティ（ツール実行や応答テキストの要約） */
+  lastActivity: string | null;
+  durationMs: number | null;
+  numTurns: number | null;
+  costUsd: number | null;
+  exitCode: number | null;
+}
+
+export interface RegisterRunMeta {
+  projectPath: string;
+  prompt: string;
+  permissionMode: PermissionMode;
+  model: string | null;
+}
+
+interface PromptRunsContextValue {
+  /** すべての実行（開始が新しい順） */
+  runs: PromptRunInfo[];
+  runningCount: number;
+  /** プロジェクトごとの最新の実行 */
+  latestRunByProject: Map<string, PromptRunInfo>;
+  registerRun: (runId: string, meta: RegisterRunMeta) => void;
+  stopRun: (runId: string) => Promise<void>;
+}
+
+const PromptRunsContext = createContext<PromptRunsContextValue | null>(null);
+
+/** 保持する実行履歴の上限（超えた分は終了済みの古いものから捨てる） */
+const MAX_FINISHED_RUNS = 50;
+/** run_id 未登録のまま届いたイベントのバッファ上限 */
+const PENDING_EVENT_LIMIT = 300;
+
+/** SIGTERM（停止ボタン）による終了コード */
+const SIGTERM_EXIT_CODE = 143;
+
+function summarizeToolInput(input: Record<string, unknown>): string {
+  const keys = ["file_path", "command", "pattern", "path", "prompt"] as const;
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value.length > 80 ? `${value.slice(0, 80)}…` : value;
+    }
+  }
+  return "";
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** イベントを 1 件適用した新しい PromptRunInfo を返す */
+function applyEvent(info: PromptRunInfo, event: PromptRunEvent): PromptRunInfo {
+  switch (event.kind) {
+    case "message": {
+      const payload = event.payload;
+      if (!payload) return info;
+      const next: PromptRunInfo = { ...info };
+      if (payload.session_id) {
+        next.sessionId = payload.session_id;
+      }
+      if (payload.type === "assistant") {
+        const content = payload.message?.content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block.type === "tool_use") {
+              const summary = summarizeToolInput(block.input);
+              next.lastActivity = summary
+                ? `⚙ ${block.name} ${summary}`
+                : `⚙ ${block.name}`;
+            } else if (block.type === "text" && block.text.trim().length > 0) {
+              next.lastActivity = truncate(block.text.trim(), 80);
+            }
+          }
+        }
+      } else if (payload.type === "result") {
+        next.durationMs =
+          typeof payload.duration_ms === "number" ? payload.duration_ms : null;
+        next.numTurns =
+          typeof payload.num_turns === "number" ? payload.num_turns : null;
+        next.costUsd =
+          typeof payload.total_cost_usd === "number"
+            ? payload.total_cost_usd
+            : null;
+      }
+      return next;
+    }
+    case "error":
+      return { ...info, lastActivity: event.text ?? info.lastActivity };
+    case "exit": {
+      const exitCode = event.exit_code ?? null;
+      const status: PromptRunStatus =
+        event.success === true
+          ? "completed"
+          : exitCode === SIGTERM_EXIT_CODE
+            ? "stopped"
+            : "failed";
+      return { ...info, status, exitCode, finishedAt: Date.now() };
+    }
+    default:
+      return info;
+  }
+}
+
+export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  // 実データは ref に持ち、version の更新で再レンダリングを起こす。
+  // 高頻度イベントの setState 連打と StrictMode の updater 二重実行を避けるため。
+  const runsRef = useRef<Map<string, PromptRunInfo>>(new Map());
+  const [version, setVersion] = useState(0);
+  const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  // registerRun 前に届いたイベントの一時バッファ（run_id ごと・受信順）
+  const pendingRef = useRef<Map<string, PromptRunEvent[]>>(new Map());
+  const pendingCountRef = useRef(0);
+
+  const trimFinished = useCallback(() => {
+    const runs = runsRef.current;
+    const finished = [...runs.values()]
+      .filter((r) => r.status !== "running")
+      .sort((a, b) => a.startedAt - b.startedAt);
+    while (finished.length > MAX_FINISHED_RUNS) {
+      const oldest = finished.shift();
+      if (oldest) runs.delete(oldest.runId);
+    }
+  }, []);
+
+  const handleEvent = useCallback(
+    (event: PromptRunEvent) => {
+      const runs = runsRef.current;
+      const info = runs.get(event.run_id);
+      if (!info) {
+        // run_id が未登録（startPromptRun の resolve 前）の間はバッファする
+        const pending = pendingRef.current;
+        const queue = pending.get(event.run_id);
+        if (queue) {
+          queue.push(event);
+        } else {
+          pending.set(event.run_id, [event]);
+        }
+        pendingCountRef.current += 1;
+        while (pendingCountRef.current > PENDING_EVENT_LIMIT) {
+          const oldestKey: string | undefined = pending.keys().next().value;
+          if (oldestKey === undefined) {
+            pendingCountRef.current = 0;
+            break;
+          }
+          const oldest = pending.get(oldestKey);
+          if (!oldest || oldest.length === 0) {
+            pending.delete(oldestKey);
+            continue;
+          }
+          oldest.shift();
+          pendingCountRef.current -= 1;
+          if (oldest.length === 0) pending.delete(oldestKey);
+        }
+        return;
+      }
+      runs.set(event.run_id, applyEvent(info, event));
+      if (event.kind === "exit") trimFinished();
+      bump();
+    },
+    [bump, trimFinished],
+  );
+
+  const registerRun = useCallback(
+    (runId: string, meta: RegisterRunMeta) => {
+      const runs = runsRef.current;
+      runs.set(runId, {
+        runId,
+        projectPath: meta.projectPath,
+        prompt: meta.prompt,
+        permissionMode: meta.permissionMode,
+        model: meta.model,
+        status: "running",
+        startedAt: Date.now(),
+        finishedAt: null,
+        sessionId: null,
+        lastActivity: null,
+        durationMs: null,
+        numTurns: null,
+        costUsd: null,
+        exitCode: null,
+      });
+      // 登録前に届いていたイベントを受信順に適用する
+      const buffered = pendingRef.current.get(runId);
+      if (buffered) {
+        pendingRef.current.delete(runId);
+        pendingCountRef.current = Math.max(
+          0,
+          pendingCountRef.current - buffered.length,
+        );
+        for (const event of buffered) {
+          const current = runs.get(runId);
+          if (current) runs.set(runId, applyEvent(current, event));
+        }
+        trimFinished();
+      }
+      bump();
+    },
+    [bump, trimFinished],
+  );
+
+  const stopRun = useCallback(async (runId: string) => {
+    await api.stopPromptRun(runId);
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+
+    api
+      .onPromptRunEvent(handleEvent)
+      .then((fn) => {
+        if (disposed) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to subscribe prompt-run-event:", error);
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [handleEvent]);
+
+  const value = useMemo<PromptRunsContextValue>(() => {
+    void version; // version 更新で再計算させる
+    const runs = [...runsRef.current.values()].sort(
+      (a, b) => b.startedAt - a.startedAt,
+    );
+    const latestRunByProject = new Map<string, PromptRunInfo>();
+    for (const run of runs) {
+      if (!latestRunByProject.has(run.projectPath)) {
+        latestRunByProject.set(run.projectPath, run);
+      }
+    }
+    return {
+      runs,
+      runningCount: runs.filter((r) => r.status === "running").length,
+      latestRunByProject,
+      registerRun,
+      stopRun,
+    };
+  }, [version, registerRun, stopRun]);
+
+  return (
+    <PromptRunsContext.Provider value={value}>
+      {children}
+    </PromptRunsContext.Provider>
+  );
+};
+
+/** Provider 配下でのみ使う（無ければ例外） */
+export function usePromptRuns(): PromptRunsContextValue {
+  const value = useContext(PromptRunsContext);
+  if (!value) {
+    throw new Error("usePromptRuns must be used within PromptRunsProvider");
+  }
+  return value;
+}
+
+/**
+ * Provider が無くても動作させたいコンポーネント用（テスト単体レンダリング等）。
+ * 無い場合は null を返し、呼び出し側は機能を無効化する。
+ */
+export function usePromptRunsOptional(): PromptRunsContextValue | null {
+  return useContext(PromptRunsContext);
+}
+
+/** 実行中の経過時間などの表示用フォーマッタ */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m${String(seconds).padStart(2, "0")}s`;
+}
+
+export const RUN_STATUS_META: Record<
+  PromptRunStatus,
+  { icon: string; label: string }
+> = {
+  running: { icon: "⏳", label: "実行中" },
+  completed: { icon: "✅", label: "完了" },
+  failed: { icon: "❌", label: "失敗" },
+  stopped: { icon: "⏹", label: "停止" },
+};

--- a/src/contexts/PromptRunsContext.tsx
+++ b/src/contexts/PromptRunsContext.tsx
@@ -1,10 +1,15 @@
 /**
  * アプリ全体でプロンプト実行の状態を共有するストア。
  *
- * PromptRunner（各プロジェクトの Prompt タブ）は会話の詳細表示を担い、
- * このストアは「どのプロジェクトで何が動いていて、どう終わったか」という
- * サマリーだけを保持する。`prompt-run-event` を独自に購読するため、
- * PromptRunner がアンマウントされても実行状況の追跡は継続する。
+ * 2 種類の状態をプロジェクト横断で保持する:
+ * 1. 実行サマリー（PromptRunInfo）— Prompts タブ / Dashboard の一覧用
+ * 2. 会話ログ（PromptConversation）— 各プロジェクトの Prompt タブの表示内容
+ *
+ * `prompt-run-event` はこの Provider だけが購読し、run_id → プロジェクトの
+ * 対応表（実行サマリー）を使って会話ログへ振り分ける。会話状態を
+ * コンポーネントではなくここに置くことで、Dashboard へ移動して
+ * ProjectScreen（と PromptRunner）がアンマウントされても、実行の追跡と
+ * 会話ログの蓄積が途切れない。
  *
  * 履歴はメモリ上のみ（アプリを終了すると消える）。
  */
@@ -18,7 +23,11 @@ import React, {
   useState,
 } from "react";
 import { api } from "../api";
-import type { PermissionMode, PromptRunEvent } from "../types";
+import type {
+  PermissionMode,
+  PromptRunEvent,
+  StreamContentBlock,
+} from "../types";
 
 export type PromptRunStatus = "running" | "completed" | "failed" | "stopped";
 
@@ -47,14 +56,64 @@ export interface RegisterRunMeta {
   model: string | null;
 }
 
+/** 会話ログの 1 エントリ（Prompt タブに表示する単位） */
+export type ConversationEntry =
+  | { id: string; kind: "prompt"; text: string }
+  | {
+      id: string;
+      kind: "block";
+      role: "assistant" | "user";
+      block: StreamContentBlock;
+    }
+  | {
+      id: string;
+      kind: "result";
+      durationMs?: number;
+      numTurns?: number;
+      costUsd?: number;
+      isError?: boolean;
+    }
+  | { id: string; kind: "error"; text: string }
+  | { id: string; kind: "exit"; success: boolean; exitCode?: number };
+
+/** プロジェクトごとの会話状態 */
+export interface PromptConversation {
+  entries: ConversationEntry[];
+  stderrLines: string[];
+  sessionId: string | null;
+  isRunning: boolean;
+  /** 実行中の run_id（送信〜run_id 確定までの間は null） */
+  activeRunId: string | null;
+}
+
+export interface SendPromptParams {
+  prompt: string;
+  permissionMode: PermissionMode;
+  model: string | null;
+}
+
+export const EMPTY_CONVERSATION: PromptConversation = {
+  entries: [],
+  stderrLines: [],
+  sessionId: null,
+  isRunning: false,
+  activeRunId: null,
+};
+
 interface PromptRunsContextValue {
   /** すべての実行（開始が新しい順） */
   runs: PromptRunInfo[];
   runningCount: number;
   /** プロジェクトごとの最新の実行 */
   latestRunByProject: Map<string, PromptRunInfo>;
+  /** プロジェクトごとの会話ログ */
+  conversations: Map<string, PromptConversation>;
   registerRun: (runId: string, meta: RegisterRunMeta) => void;
   stopRun: (runId: string) => Promise<void>;
+  /** プロンプトを送信する（会話へのエントリ追加〜実行登録まで担う） */
+  sendPrompt: (projectPath: string, params: SendPromptParams) => Promise<void>;
+  /** 会話ログをクリアして新しい会話を始める */
+  resetConversation: (projectPath: string) => void;
 }
 
 const PromptRunsContext = createContext<PromptRunsContextValue | null>(null);
@@ -135,12 +194,131 @@ function applyEvent(info: PromptRunInfo, event: PromptRunEvent): PromptRunInfo {
   }
 }
 
+let conversationEntrySeq = 0;
+const nextEntryId = (): string => {
+  conversationEntrySeq += 1;
+  return `prompt-entry-${conversationEntrySeq}`;
+};
+
+const toErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "不明なエラーが発生しました";
+};
+
+/**
+ * イベントを 1 件適用した新しい会話状態を返す。
+ * activeRunId と一致しないイベント（古い実行の残骸など）は無視する。
+ */
+function applyConversationEvent(
+  conversation: PromptConversation,
+  event: PromptRunEvent,
+): PromptConversation {
+  if (conversation.activeRunId !== event.run_id) return conversation;
+
+  switch (event.kind) {
+    case "message": {
+      const payload = event.payload;
+      if (!payload) return conversation;
+
+      let next = conversation;
+      if (payload.session_id && payload.session_id !== next.sessionId) {
+        next = { ...next, sessionId: payload.session_id };
+      }
+
+      if (payload.type === "assistant" || payload.type === "user") {
+        const role = payload.type;
+        const content = payload.message?.content;
+        const blocks: StreamContentBlock[] = Array.isArray(content)
+          ? content
+          : typeof content === "string" && content.length > 0
+            ? [{ type: "text", text: content }]
+            : [];
+
+        // user メッセージはプロンプトのエコーになるため tool_result のみ表示
+        const visible =
+          role === "user"
+            ? blocks.filter((block) => block.type === "tool_result")
+            : blocks;
+        if (visible.length === 0) return next;
+
+        return {
+          ...next,
+          entries: [
+            ...next.entries,
+            ...visible.map<ConversationEntry>((block) => ({
+              id: nextEntryId(),
+              kind: "block",
+              role,
+              block,
+            })),
+          ],
+        };
+      }
+      if (payload.type === "result") {
+        return {
+          ...next,
+          entries: [
+            ...next.entries,
+            {
+              id: nextEntryId(),
+              kind: "result",
+              durationMs: payload.duration_ms,
+              numTurns: payload.num_turns,
+              costUsd: payload.total_cost_usd,
+              isError: payload.is_error,
+            },
+          ],
+        };
+      }
+      return next;
+    }
+    case "stderr": {
+      if (!event.text) return conversation;
+      return {
+        ...conversation,
+        stderrLines: [...conversation.stderrLines, event.text],
+      };
+    }
+    case "error":
+      return {
+        ...conversation,
+        entries: [
+          ...conversation.entries,
+          {
+            id: nextEntryId(),
+            kind: "error",
+            text: event.text ?? "不明なエラーが発生しました",
+          },
+        ],
+      };
+    case "exit":
+      return {
+        ...conversation,
+        isRunning: false,
+        activeRunId: null,
+        entries: [
+          ...conversation.entries,
+          {
+            id: nextEntryId(),
+            kind: "exit",
+            success: event.success === true,
+            exitCode: event.exit_code ?? undefined,
+          },
+        ],
+      };
+    default:
+      return conversation;
+  }
+}
+
 export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   // 実データは ref に持ち、version の更新で再レンダリングを起こす。
   // 高頻度イベントの setState 連打と StrictMode の updater 二重実行を避けるため。
   const runsRef = useRef<Map<string, PromptRunInfo>>(new Map());
+  const conversationsRef = useRef<Map<string, PromptConversation>>(new Map());
   const [version, setVersion] = useState(0);
   const bump = useCallback(() => setVersion((v) => v + 1), []);
 
@@ -191,6 +369,13 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
         return;
       }
       runs.set(event.run_id, applyEvent(info, event));
+      // 実行サマリーの run_id → projectPath を使って会話ログへも振り分ける
+      const conversation =
+        conversationsRef.current.get(info.projectPath) ?? EMPTY_CONVERSATION;
+      conversationsRef.current.set(
+        info.projectPath,
+        applyConversationEvent(conversation, event),
+      );
       if (event.kind === "exit") trimFinished();
       bump();
     },
@@ -216,7 +401,17 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
         costUsd: null,
         exitCode: null,
       });
-      // 登録前に届いていたイベントを受信順に適用する
+      // 会話を実行に紐付ける（送信済みプロンプト表示は sendPrompt が済ませている）
+      const conversations = conversationsRef.current;
+      const conversation =
+        conversations.get(meta.projectPath) ?? EMPTY_CONVERSATION;
+      conversations.set(meta.projectPath, {
+        ...conversation,
+        isRunning: true,
+        activeRunId: runId,
+      });
+
+      // 登録前に届いていたイベントを受信順に適用する（サマリー・会話の両方）
       const buffered = pendingRef.current.get(runId);
       if (buffered) {
         pendingRef.current.delete(runId);
@@ -225,8 +420,14 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
           pendingCountRef.current - buffered.length,
         );
         for (const event of buffered) {
-          const current = runs.get(runId);
-          if (current) runs.set(runId, applyEvent(current, event));
+          const currentRun = runs.get(runId);
+          if (currentRun) runs.set(runId, applyEvent(currentRun, event));
+          const currentConversation =
+            conversations.get(meta.projectPath) ?? EMPTY_CONVERSATION;
+          conversations.set(
+            meta.projectPath,
+            applyConversationEvent(currentConversation, event),
+          );
         }
         trimFinished();
       }
@@ -238,6 +439,85 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
   const stopRun = useCallback(async (runId: string) => {
     await api.stopPromptRun(runId);
   }, []);
+
+  /**
+   * プロンプト送信の一連の流れを担う:
+   * ユーザー発言の追加 → CLI 起動 → 実行の登録（バッファ済みイベントの反映）。
+   * 失敗時はエラー行を会話に追加して実行中フラグを下ろす。
+   */
+  const sendPrompt = useCallback(
+    async (projectPath: string, params: SendPromptParams) => {
+      const text = params.prompt.trim();
+      if (!text) return;
+
+      const conversations = conversationsRef.current;
+      const before = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
+      const resumeSessionId = before.sessionId;
+      conversations.set(projectPath, {
+        ...before,
+        entries: [
+          ...before.entries,
+          { id: nextEntryId(), kind: "prompt", text },
+        ],
+        stderrLines: [],
+        isRunning: true,
+        activeRunId: null,
+      });
+      bump();
+
+      try {
+        const runId = await api.startPromptRun({
+          projectPath,
+          prompt: text,
+          permissionMode: params.permissionMode,
+          resumeSessionId,
+          model: params.model,
+        });
+        registerRun(runId, {
+          projectPath,
+          prompt: text,
+          permissionMode: params.permissionMode,
+          model: params.model,
+        });
+      } catch (error: unknown) {
+        const current = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
+        conversations.set(projectPath, {
+          ...current,
+          isRunning: false,
+          activeRunId: null,
+          entries: [
+            ...current.entries,
+            {
+              id: nextEntryId(),
+              kind: "error",
+              text: `実行を開始できませんでした: ${toErrorMessage(error)}`,
+            },
+          ],
+        });
+        bump();
+      }
+    },
+    [bump, registerRun],
+  );
+
+  /**
+   * 会話ログをクリアする。実行中の場合は実行自体は継続し、
+   * 以降のイベントは（activeRunId を保持しているため）引き続き追記される。
+   */
+  const resetConversation = useCallback(
+    (projectPath: string) => {
+      const conversations = conversationsRef.current;
+      const current = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
+      conversations.set(projectPath, {
+        ...current,
+        entries: [],
+        stderrLines: [],
+        sessionId: null,
+      });
+      bump();
+    },
+    [bump],
+  );
 
   useEffect(() => {
     let disposed = false;
@@ -277,10 +557,13 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
       runs,
       runningCount: runs.filter((r) => r.status === "running").length,
       latestRunByProject,
+      conversations: new Map(conversationsRef.current),
       registerRun,
       stopRun,
+      sendPrompt,
+      resetConversation,
     };
-  }, [version, registerRun, stopRun]);
+  }, [version, registerRun, stopRun, sendPrompt, resetConversation]);
 
   return (
     <PromptRunsContext.Provider value={value}>

--- a/src/styles/prompt-runner.css
+++ b/src/styles/prompt-runner.css
@@ -1,0 +1,455 @@
+/**
+ * PromptRunner styles
+ * design-tokens.css の CSS 変数を利用し、App.css の既存カード表現に揃える
+ */
+
+.prompt-runner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  height: 100%;
+  min-height: 0;
+  padding: var(--spacing-5);
+}
+
+/* ------------------------------------------------------------------ */
+/* CLI ステータス                                                       */
+/* ------------------------------------------------------------------ */
+
+.prompt-runner__banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4) var(--spacing-5);
+  background: var(--color-warning-50);
+  border: 1px solid var(--color-warning-300);
+  border-radius: var(--radius-base);
+  color: var(--color-warning-900);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+}
+
+.prompt-runner__banner-icon {
+  flex-shrink: 0;
+}
+
+.prompt-runner__cli-status {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  color: var(--color-secondary-500);
+}
+
+/* ------------------------------------------------------------------ */
+/* 会話エリア                                                           */
+/* ------------------------------------------------------------------ */
+
+.prompt-runner__log {
+  flex: 1 1 auto;
+  min-height: 240px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  padding: var(--spacing-5);
+  background: #ffffff;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-base);
+}
+
+.prompt-runner__placeholder {
+  margin: 0;
+  color: var(--color-secondary-400);
+  font-size: var(--font-size-sm);
+}
+
+.prompt-runner__bubble {
+  padding: var(--spacing-4) var(--spacing-5);
+  border-radius: var(--radius-base);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.prompt-runner__bubble--user {
+  align-self: flex-end;
+  max-width: 80%;
+  background: var(--color-primary-50);
+  border: 1px solid var(--color-primary-200);
+  color: var(--color-primary-900);
+}
+
+/* markdown 本文 */
+.prompt-runner__markdown {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-gray-800);
+  word-break: break-word;
+}
+
+.prompt-runner__markdown > *:first-child {
+  margin-top: 0;
+}
+
+.prompt-runner__markdown > *:last-child {
+  margin-bottom: 0;
+}
+
+.prompt-runner__markdown pre {
+  padding: var(--spacing-4);
+  background: var(--color-secondary-50);
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runner__markdown code {
+  font-family: var(--font-family-mono);
+  font-size: 0.9em;
+}
+
+.prompt-runner__markdown :not(pre) > code {
+  padding: 1px 4px;
+  background: var(--color-secondary-100);
+  border-radius: var(--radius-sm);
+}
+
+/* 折りたたみトリガ */
+.prompt-runner__disclosure {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  width: 100%;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-secondary-600);
+  font-size: var(--font-size-xs);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.prompt-runner__disclosure:hover {
+  background: var(--color-secondary-50);
+}
+
+.prompt-runner__disclosure:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}
+
+.prompt-runner__pre {
+  margin: var(--spacing-2) 0 0;
+  padding: var(--spacing-4);
+  max-height: 320px;
+  overflow: auto;
+  background: var(--color-secondary-50);
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.prompt-runner__truncated-note {
+  margin: var(--spacing-2) 0 0;
+  color: var(--color-secondary-400);
+  font-size: var(--font-size-xs);
+}
+
+/* thinking */
+.prompt-runner__thinking {
+  border-left: 2px solid var(--color-secondary-200);
+  padding-left: var(--spacing-3);
+}
+
+/* tool_use */
+.prompt-runner__tool-use {
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  background: var(--color-secondary-50);
+}
+
+.prompt-runner__disclosure--tool {
+  gap: var(--spacing-4);
+}
+
+.prompt-runner__tool-name {
+  flex-shrink: 0;
+  font-family: var(--font-family-mono);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-secondary-700);
+}
+
+.prompt-runner__tool-summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-family-mono);
+  color: var(--color-secondary-500);
+}
+
+/* tool_result */
+.prompt-runner__tool-result {
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-2);
+}
+
+.prompt-runner__tool-result--error {
+  border-color: var(--color-error-300);
+  background: var(--color-error-50);
+}
+
+.prompt-runner__tool-result--error .prompt-runner__disclosure {
+  color: var(--color-error-700);
+}
+
+.prompt-runner__tool-result--error .prompt-runner__pre {
+  border-color: var(--color-error-200);
+  background: #ffffff;
+}
+
+/* result チップ */
+.prompt-runner__result {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+}
+
+.prompt-runner__chip {
+  padding: var(--spacing-1) var(--spacing-3);
+  background: var(--color-secondary-100);
+  border-radius: var(--radius-full);
+  color: var(--color-secondary-600);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runner__result--error .prompt-runner__chip {
+  background: var(--color-error-100);
+  color: var(--color-error-700);
+}
+
+/* stderr */
+.prompt-runner__stderr {
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-2);
+}
+
+.prompt-runner__badge {
+  margin-left: auto;
+  padding: 0 var(--spacing-3);
+  background: var(--color-secondary-200);
+  border-radius: var(--radius-full);
+  color: var(--color-secondary-700);
+  font-size: var(--font-size-xs);
+}
+
+/* エラー行 / 終了表示 */
+.prompt-runner__error-row {
+  padding: var(--spacing-3) var(--spacing-4);
+  background: var(--color-error-50);
+  border: 1px solid var(--color-error-200);
+  border-radius: var(--radius-sm);
+  color: var(--color-error-700);
+  font-size: var(--font-size-sm);
+}
+
+.prompt-runner__exit {
+  color: var(--color-secondary-400);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runner__exit--error {
+  color: var(--color-error-600);
+  font-weight: var(--font-weight-medium);
+}
+
+/* 実行中インジケータ */
+.prompt-runner__running {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  color: var(--color-primary-600);
+  font-size: var(--font-size-sm);
+}
+
+.prompt-runner__spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-primary-200);
+  border-top-color: var(--color-primary-600);
+  border-radius: var(--radius-full);
+  animation: prompt-runner-spin 0.8s linear infinite;
+}
+
+@keyframes prompt-runner-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prompt-runner__spinner {
+    animation: none;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* コンポーザー                                                         */
+/* ------------------------------------------------------------------ */
+
+.prompt-runner__composer {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background: #ffffff;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-base);
+}
+
+.prompt-runner__session {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-secondary-500);
+}
+
+.prompt-runner__session-label {
+  font-family: var(--font-family-mono);
+}
+
+.prompt-runner__link-button {
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--color-primary-600);
+  font-size: var(--font-size-xs);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.prompt-runner__link-button:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}
+
+.prompt-runner__textarea {
+  width: 100%;
+  min-height: 4rem;
+  max-height: 12rem;
+  padding: var(--spacing-4);
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.prompt-runner__textarea:focus {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 2px var(--color-primary-100);
+}
+
+.prompt-runner__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--spacing-4);
+}
+
+.prompt-runner__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.prompt-runner__field label {
+  color: var(--color-secondary-500);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runner__field select {
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-size: var(--font-size-sm);
+}
+
+.prompt-runner__field select:disabled {
+  background: var(--color-secondary-100);
+  color: var(--color-secondary-400);
+  cursor: not-allowed;
+}
+
+.prompt-runner__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin-left: auto;
+}
+
+/*
+ * グローバルの .btn-primary / .btn-secondary は App.css と editors.css で
+ * 二重定義されており、後勝ちする editors.css 側が未定義の --accent-color を
+ * 参照するため背景が透明になる（白文字が消える）。
+ * ここでは読み込み順に左右されない専用クラスで色を確定させる。
+ */
+.prompt-runner__button {
+  padding: 8px 18px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.prompt-runner__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.prompt-runner__button--primary {
+  background: var(--color-primary-600);
+  color: #fff;
+}
+
+.prompt-runner__button--primary:hover:not(:disabled) {
+  background: var(--color-primary-700);
+}
+
+.prompt-runner__button--secondary {
+  background: #fff;
+  color: var(--color-secondary-700);
+  border-color: var(--color-secondary-300);
+}
+
+.prompt-runner__button--secondary:hover:not(:disabled) {
+  background: var(--color-secondary-100);
+}
+
+.prompt-runner__button:focus-visible {
+  outline: 2px solid var(--color-primary-500);
+  outline-offset: 2px;
+}

--- a/src/styles/prompt-runner.css
+++ b/src/styles/prompt-runner.css
@@ -3,11 +3,26 @@
  * design-tokens.css の CSS 変数を利用し、App.css の既存カード表現に揃える
  */
 
+/*
+ * .project-screen は height 固定 + overflow: hidden の内部スクロール設計。
+ * Prompt タブもそれに合わせ、タブ以下の残り高さいっぱいに広がる flex 列にする。
+ * 会話ログ（__log）だけが内部スクロールし、コンポーザーは常に画面内に留まる。
+ * ここを auto 高さにすると、長い会話でコンポーザーが overflow: hidden の外に
+ * 押し出されてクリックできなくなる。
+ */
+.project-prompt-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .prompt-runner {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: var(--spacing-4);
-  height: 100%;
   min-height: 0;
   padding: var(--spacing-5);
 }

--- a/src/styles/prompt-runner.css
+++ b/src/styles/prompt-runner.css
@@ -345,13 +345,19 @@
   outline-offset: 2px;
 }
 
+/*
+ * 色は --input-bg / --input-border を使わず直接指定する。
+ * これらは design-tokens.css の :root 内 @media (prefers-color-scheme: dark)
+ * でダーク値に反転するが、アプリ本体（App.css）は白背景固定のライト UI のため、
+ * OS がダークモードだと入力欄だけが黒くなり文字が読めなくなる。
+ */
 .prompt-runner__textarea {
   width: 100%;
   min-height: 4rem;
   max-height: 12rem;
   padding: var(--spacing-4);
-  background: var(--input-bg);
-  border: 1px solid var(--input-border);
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
   border-radius: var(--radius-sm);
   color: var(--color-gray-800);
   font-family: inherit;
@@ -361,9 +367,13 @@
   box-sizing: border-box;
 }
 
+.prompt-runner__textarea::placeholder {
+  color: var(--color-gray-500);
+}
+
 .prompt-runner__textarea:focus {
   outline: none;
-  border-color: var(--input-border-focus);
+  border-color: var(--color-primary-500);
   box-shadow: 0 0 0 2px var(--color-primary-100);
 }
 
@@ -387,8 +397,8 @@
 
 .prompt-runner__field select {
   padding: var(--spacing-2) var(--spacing-3);
-  background: var(--input-bg);
-  border: 1px solid var(--input-border);
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
   border-radius: var(--radius-sm);
   color: var(--color-gray-800);
   font-size: var(--font-size-sm);

--- a/src/styles/prompt-runs.css
+++ b/src/styles/prompt-runs.css
@@ -1,0 +1,300 @@
+/**
+ * マルチプロジェクトのプロンプト実行状況ビュー
+ * - ナビの実行中バッジ
+ * - Prompts タブ（全実行一覧）
+ * - Dashboard の実行中セクション / プロジェクトカードのバッジ
+ *
+ * アプリ本体は固定ライト UI のため、色はライト前提で直接指定する
+ * （--input-bg などダーク反転するトークンは使わない。prompt-runner.css 参照）。
+ */
+
+/* ---- ナビバッジ ---- */
+
+.nav-running-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  padding: 1px 8px;
+  background: var(--color-primary-500);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  vertical-align: middle;
+}
+
+.nav-running-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #fff;
+  animation: prompt-runs-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes prompt-runs-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-running-badge__dot {
+    animation: none;
+  }
+}
+
+/* ---- Prompts タブ（一覧） ---- */
+
+.prompts-overview {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: var(--spacing-6) var(--spacing-6) var(--spacing-10);
+}
+
+.prompts-overview__header {
+  margin-bottom: var(--spacing-5);
+}
+
+.prompts-overview__title {
+  margin: 0 0 var(--spacing-1);
+  color: var(--color-gray-800);
+  font-size: var(--font-size-2xl);
+}
+
+.prompts-overview__subtitle {
+  margin: 0;
+  color: var(--color-secondary-500);
+  font-size: var(--font-size-sm);
+}
+
+.prompts-overview__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-4);
+}
+
+.prompts-overview__filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 999px;
+  color: var(--color-gray-800);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.prompts-overview__filter--active {
+  background: var(--color-primary-600);
+  border-color: var(--color-primary-600);
+  color: #fff;
+}
+
+.prompts-overview__filter-count {
+  padding: 0 6px;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.prompts-overview__filter--active .prompts-overview__filter-count {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.prompts-overview__empty {
+  padding: var(--spacing-8);
+  background: #fff;
+  border: 1px dashed var(--color-gray-300);
+  border-radius: var(--radius-md);
+  color: var(--color-secondary-500);
+  text-align: center;
+}
+
+.prompts-overview__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ---- 実行 1 件の行（Prompts タブ / Dashboard 共用） ---- */
+
+.prompt-runs-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+  padding: var(--spacing-4);
+  background: #fff;
+  border: 1px solid var(--color-gray-200);
+  border-left: 4px solid var(--color-gray-300);
+  border-radius: var(--radius-md);
+}
+
+.prompt-runs-row--running {
+  border-left-color: var(--color-primary-500);
+}
+
+.prompt-runs-row--completed {
+  border-left-color: var(--color-success-500);
+}
+
+.prompt-runs-row--failed {
+  border-left-color: var(--color-error-500);
+}
+
+.prompt-runs-row--stopped {
+  border-left-color: var(--color-warning-500);
+}
+
+.prompt-runs-row__icon {
+  flex-shrink: 0;
+  font-size: 1.1rem;
+  line-height: 1.5;
+}
+
+.prompt-runs-row__icon--running {
+  animation: prompt-runs-pulse 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prompt-runs-row__icon--running {
+    animation: none;
+  }
+}
+
+.prompt-runs-row__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.prompt-runs-row__title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--spacing-2);
+}
+
+.prompt-runs-row__project {
+  color: var(--color-gray-800);
+  font-weight: 700;
+}
+
+.prompt-runs-row__meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  color: var(--color-secondary-500);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runs-row__prompt {
+  margin-top: 2px;
+  overflow: hidden;
+  color: var(--color-gray-800);
+  font-size: var(--font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prompt-runs-row__activity {
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--color-secondary-500);
+  font-family: var(--font-family-mono, monospace);
+  font-size: var(--font-size-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.prompt-runs-row__actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: var(--spacing-2);
+}
+
+.prompt-runs-row__button {
+  padding: 5px 14px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 6px;
+  color: var(--color-gray-800);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.prompt-runs-row__button:hover {
+  background: var(--color-secondary-100);
+}
+
+.prompt-runs-row__button--primary {
+  background: var(--color-primary-600);
+  border-color: var(--color-primary-600);
+  color: #fff;
+}
+
+.prompt-runs-row__button--primary:hover {
+  background: var(--color-primary-700);
+}
+
+/* ---- Dashboard: 実行中セクション ---- */
+
+.dashboard-running-section {
+  margin-bottom: var(--spacing-6);
+}
+
+.dashboard-running-section .prompt-runs-row {
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.06));
+}
+
+.dashboard-running-section__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ---- Dashboard: プロジェクトカードの状態バッジ ---- */
+
+.project-run-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.project-run-badge--running {
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
+.project-run-badge--completed {
+  background: var(--color-success-100);
+  color: var(--color-success-700);
+}
+
+.project-run-badge--failed {
+  background: var(--color-error-100);
+  color: var(--color-error-700);
+}
+
+.project-run-badge--stopped {
+  background: var(--color-warning-100);
+  color: var(--color-warning-700);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,3 +138,66 @@ export interface Agent {
   name: string;
   content: string;
 }
+
+// ============================================================================
+// In-App Prompt Runner (Issue #181)
+// Rust 側 DTO と同じ snake_case。例外は PermissionMode の値のみ（CLI 引数と同一文字列）
+// ============================================================================
+
+export type PermissionMode = "plan" | "acceptEdits" | "bypassPermissions";
+
+export interface ClaudeCliStatus {
+  available: boolean;
+  path?: string | null;
+  version?: string | null;
+  error?: string | null;
+}
+
+export type PromptRunEventKind = "message" | "stderr" | "exit" | "error";
+
+export interface PromptRunEvent {
+  run_id: string;
+  kind: PromptRunEventKind;
+  payload?: StreamJsonMessage | null;
+  text?: string | null;
+  exit_code?: number | null;
+  success?: boolean | null;
+}
+
+export type StreamContentBlock =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking?: string }
+  | {
+      type: "tool_use";
+      id: string;
+      name: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      type: "tool_result";
+      tool_use_id: string;
+      content?: unknown;
+      is_error?: boolean;
+    };
+
+export interface StreamJsonMessage {
+  type: string; // "system" | "assistant" | "user" | "result" | ...
+  subtype?: string;
+  session_id?: string;
+  model?: string;
+  message?: { role: string; content: string | StreamContentBlock[] };
+  result?: string;
+  is_error?: boolean;
+  duration_ms?: number;
+  num_turns?: number;
+  total_cost_usd?: number;
+  [key: string]: unknown;
+}
+
+export interface StartPromptRunParams {
+  projectPath: string;
+  prompt: string;
+  permissionMode: PermissionMode;
+  resumeSessionId?: string | null;
+  model?: string | null;
+}


### PR DESCRIPTION
## 概要

プロジェクト画面に **Prompt タブ** を追加し、Claude Code Manager 内からプロンプトを書いて Claude Code に指示を出せるようにしました。応答はアプリ内にリアルタイムでストリーミング表示されます。

Rust バックエンドから `claude` CLI をヘッドレス起動し、`stream-json` 出力を Tauri イベントでフロントへ中継する構成です。

## 使い方

1. Dashboard → プロジェクトを開く → **Prompt** タブ
2. 権限モードを選ぶ（既定は「読み取り専用」）
3. プロンプトを入力して送信（Cmd/Ctrl + Enter でも送信）

実行後は同じセッションに続けて指示を送れます（「新しい会話」で切り替え）。

## 実装

### バックエンド `src-tauri/src/prompt_runner.rs`

```
claude -p --output-format stream-json --verbose --permission-mode <mode> [--resume <id>] [--model <m>]
```

- **CLI の解決**: GUI アプリを Finder から起動すると PATH が最小限になるため、`CLAUDE_CLI_PATH` → ログインシェルの `command -v` → 既知の候補 → `PATH` の順で多段解決します。成功結果はキャッシュし、送信のたびにログインシェルを起動しません
- **プロンプトの受け渡し**: argv ではなく stdin。書き込みは出力の読み取りと並行させ、パイプバッファ（64KB）を超える長いプロンプトでデッドロックしないようにしています
- **引数の検証**: `--resume` / `--model` の値は長さ・文字種・先頭ハイフンを検証し、引数インジェクションを防ぎます
- **停止**: unix ではプロセスグループごと SIGTERM → 2 秒後に SIGKILL。子孫プロセスを残しません

追加コマンド: `get_claude_cli_status` / `start_prompt_run` / `stop_prompt_run`

### フロントエンド `src/components/PromptRunner.tsx`

- assistant テキスト・`tool_use`・`tool_result`・result サマリ・stderr を折りたたみ付きで表示
- テキストは marked → **DOMPurify でサニタイズ**してから描画
- 権限モードは UI 選択式。ヘッドレス実行では対話的な許可プロンプトに答えられないため明示的に選ぶ必要があります
  - `plan`（既定・読み取り専用） / `acceptEdits` / `bypassPermissions`
  - `bypassPermissions` を選んだときのみ確認ダイアログを表示
- 直近の `session_id` を保持し、次の送信で `--resume` に渡して会話を継続
- `run_id` が返る前に届いたイベントはバッファし、確定後に順序どおり流します

## 併せて修正した不具合

実装中に見つかったものです。

| 箇所 | 内容 |
|---|---|
| `ProjectScreen` | 実行完了時に `loadProjectData` を呼ぶと全画面ローディングに切り替わり、Prompt タブごと unmount されて会話ログが消えていた。一覧だけを静かに更新する経路に変更 |
| `ProjectScreen` | 一度開いた Prompt タブはマウントしたままにし、タブを行き来しても会話が失われないようにした |
| `api-mock` | 購読を handler の関数参照で `Set` に入れていたため、StrictMode の二重購読が 1 件に潰れ、先に走る解除で購読が消えていた（ブラウザ単体開発でイベントが一切届かない状態）。購読単位のエントリに変更 |
| `prompt-runner.css` | グローバルの `.btn-primary` は `editors.css` が未定義の `--accent-color` を参照するため背景が透明になり、白文字のボタンが見えなくなっていた。専用クラスで色を確定 |

## 動作確認

- `npm run cargo:clippy` — 新規コードで warning なし（既存の 21 件は `tests.rs` の従来分）
- `npm run cargo:test` — 54 passed
- `npx tsc --noEmit` — エラーなし
- `npx vitest run` — 83 passed / 10 skipped（新規 `PromptRunner.test.tsx` 12 件を含む）
- `npm run build` / `cargo build` — 成功
- **実 CLI との突き合わせ**: `claude -p --output-format stream-json --verbose` を実行し、`system/init` → `assistant`(text, tool_use) → `user`(tool_result) → `result` のイベント形が実装の想定と一致することを確認。`--resume` での会話継続も確認
- **UI 動作確認**: モック API で送信 → ストリーミング表示 → ツール表示 → result サマリ → 完了、タブ往復での会話保持、停止、`bypassPermissions` の確認ダイアログを確認

## 補足

- `rate_limit_event` など契約に無い `type` のイベントも CLI から流れてきますが、未知の type は無視されるため問題ありません
- Windows は `taskkill /T /F` での停止にフォールバックします（プロセスグループ制御は unix のみ）

## 追記: マルチプロジェクトの実行状況ビュー

複数プロジェクトのプロンプト実行状況を一目で把握できるようにしました。

- **ナビの Prompts タブ**: 全プロジェクトの実行を状態フィルタ（実行中/完了/失敗/停止）付きで一覧。実行中はその場で停止でき、「開く」で該当プロジェクトの Prompt タブへ直行
- **ナビバッジ**: 実行中の件数をパルス付きバッジで常時表示
- **Dashboard**: 上部に「実行中のプロンプト」セクション（経過時間・最終アクティビティ・停止/開く）、プロジェクトカードに最新実行の状態バッジ
- 実装は `PromptRunsContext`（アプリ全体のストア）。`prompt-run-event` を独自購読するため、プロジェクト画面を離れても追跡が継続します。履歴はアプリ起動中のみ保持

## 追記: OS ダークモードで入力文字が見えない問題の修正

`design-tokens.css` の `--input-bg` が OS ダークモード時に反転する一方、アプリ本体は固定ライト UI のため、入力欄の背景と文字色が同色になり入力内容が見えませんでした。色を直接指定してライト UI に揃えています。

close #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

