### PR TITLE
Dashboardのプロジェクト件数表示と実際の表示件数の不一致を解消

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -262,6 +262,29 @@ body {
   border-radius: 2rem;
 }
 
+.projects-show-all {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.show-all-projects-button {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  border-radius: 2rem;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.show-all-projects-button:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
 .section-title {
   font-size: 1.5rem;
   font-weight: 600;

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,6 +16,9 @@ interface DashboardProps {
   onOpenPromptRun?: (projectPath: string) => void;
 }
 
+/** Recent Projects を折りたたみ表示するときの件数 */
+const COLLAPSED_PROJECT_COUNT = 6;
+
 /** Dashboard 上部の「実行中のプロンプト」セクション */
 const RunningPromptsSection: React.FC<{
   runs: PromptRunInfo[];
@@ -306,6 +309,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [showAllProjects, setShowAllProjects] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [updating, setUpdating] = useState<{
@@ -493,21 +497,40 @@ export const Dashboard: React.FC<DashboardProps> = ({
             description="No Claude Code projects have been created yet"
           />
         ) : (
-          <div
-            className={`projects-grid ${updating.projects ? "updating" : ""}`}
-          >
-            {projects.slice(0, 6).map((project) => (
-              <ProjectCard
-                key={project.project_path}
-                project={project}
-                latestRun={
-                  runsStore?.latestRunByProject.get(project.project_path) ??
-                  null
-                }
-                onClick={() => onProjectClick?.(project.project_path)}
-              />
-            ))}
-          </div>
+          <>
+            <div
+              className={`projects-grid ${updating.projects ? "updating" : ""}`}
+            >
+              {(showAllProjects
+                ? projects
+                : projects.slice(0, COLLAPSED_PROJECT_COUNT)
+              ).map((project) => (
+                <ProjectCard
+                  key={project.project_path}
+                  project={project}
+                  latestRun={
+                    runsStore?.latestRunByProject.get(project.project_path) ??
+                    null
+                  }
+                  onClick={() => onProjectClick?.(project.project_path)}
+                />
+              ))}
+            </div>
+            {projects.length > COLLAPSED_PROJECT_COUNT && (
+              <div className="projects-show-all">
+                <button
+                  type="button"
+                  className="show-all-projects-button"
+                  aria-expanded={showAllProjects}
+                  onClick={() => setShowAllProjects((prev) => !prev)}
+                >
+                  {showAllProjects
+                    ? "Show less"
+                    : `Show all ${projects.length} projects`}
+                </button>
+              </div>
+            )}
+          </>
         )}
       </section>
     </div>


### PR DESCRIPTION
## 問題

ダッシュボードの Recent Projects セクションで、ヘッダーのカウンターは全プロジェクト数（例: 12 projects）を表示する一方、グリッドは先頭6件しか描画されず、残りのプロジェクトを見る手段がなかった。

## 原因

`Dashboard.tsx` がグリッド描画時に `projects.slice(0, 6)` で固定的に切り詰めていたため。バックエンド（`get_project_summary`）は全プロジェクトを最終更新順で返しており、フロントの表示のみの問題。

## 修正内容

- `src/components/Dashboard.tsx`
  - `COLLAPSED_PROJECT_COUNT = 6` 定数と `showAllProjects` state を追加
  - デフォルトは従来どおり6件表示のまま、7件以上ある場合に「Show all N projects」ボタンを表示。クリックで全件展開、「Show less」で折りたたみに戻る
- `src/App.css`
  - トグルボタン（`.projects-show-all` / `.show-all-projects-button`）のスタイルを追加（既存のデザイントークンを使用）

## テスト

- `npm run check`（TypeScript / cargo check）: パス
- `npm run test`: 93 passed / 10 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)