### PR TITLE
Dashboard にプロジェクト横断のプロンプト実行状況ボードを追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -262,6 +262,29 @@ body {
   border-radius: 2rem;
 }
 
+.projects-show-all {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.show-all-projects-button {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  border-radius: 2rem;
+  padding: 0.5rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.show-all-projects-button:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
 .section-title {
   font-size: 1.5rem;
   font-weight: 600;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,6 +122,7 @@ function App() {
           <Dashboard
             onProjectClick={navigateToProject}
             onOpenPromptRun={navigateToProjectPrompt}
+            onOpenPromptsTab={() => setActiveTab("prompts")}
           />
         );
       case "sessions":

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,102 +1,128 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { api } from "../api";
 import {
-  formatElapsed,
   RUN_STATUS_META,
   usePromptRunsOptional,
   type PromptRunInfo,
+  type PromptRunStatus,
 } from "../contexts/PromptRunsContext";
 import { formatDateForContext } from "../utils/dateUtils";
-import { getProjectDisplayName } from "../utils/pathUtils";
-import type { SessionStats, ProjectSummary } from "../types";
+import { PromptRunRow } from "./PromptRunRow";
+import type { ClaudeSession, SessionStats, ProjectSummary } from "../types";
 
 interface DashboardProps {
   onProjectClick?: (projectPath: string) => void;
   /** 実行中プロンプトの行やバッジから Prompt タブ直行で開く */
   onOpenPromptRun?: (projectPath: string) => void;
+  /** 「すべて見る」から Prompts タブへ移動する */
+  onOpenPromptsTab?: () => void;
 }
 
 /** Recent Projects を折りたたみ表示するときの件数 */
 const COLLAPSED_PROJECT_COUNT = 6;
 
-/** Dashboard 上部の「実行中のプロンプト」セクション */
-const RunningPromptsSection: React.FC<{
+/** Dashboard の実行状況セクションに表示する最大件数 */
+const STATUS_BOARD_MAX_ROWS = 6;
+
+/**
+ * Dashboard 上部の「プロンプト実行状況」セクション。
+ * 実行中だけでなく完了・失敗・停止も含めた直近の実行を一覧し、
+ * プロジェクト横断の状況をダッシュボードだけで把握できるようにする。
+ */
+const PromptStatusSection: React.FC<{
   runs: PromptRunInfo[];
   onOpen?: (projectPath: string) => void;
   onStop: (runId: string) => void;
-}> = ({ runs, onOpen, onStop }) => {
+  onOpenAll?: () => void;
+}> = ({ runs, onOpen, onStop, onOpenAll }) => {
   const [now, setNow] = useState(() => Date.now());
 
+  const hasRunning = runs.some((run) => run.status === "running");
   useEffect(() => {
+    if (!hasRunning) return;
     const timer = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(timer);
-  }, []);
+  }, [hasRunning]);
+
+  const counts = useMemo(() => {
+    const c: Record<PromptRunStatus, number> = {
+      running: 0,
+      completed: 0,
+      failed: 0,
+      stopped: 0,
+    };
+    for (const run of runs) c[run.status] += 1;
+    return c;
+  }, [runs]);
+
+  // 実行中を先頭に、あとは新しい順
+  const sorted = useMemo(
+    () =>
+      [...runs].sort(
+        (a, b) =>
+          (a.status === "running" ? 0 : 1) - (b.status === "running" ? 0 : 1) ||
+          b.startedAt - a.startedAt,
+      ),
+    [runs],
+  );
+  const visible = sorted.slice(0, STATUS_BOARD_MAX_ROWS);
+  const hiddenCount = sorted.length - visible.length;
 
   if (runs.length === 0) return null;
 
   return (
     <section
-      className="dashboard-running-section"
-      aria-labelledby="running-prompts-heading"
+      className="dashboard-prompt-status"
+      aria-labelledby="prompt-status-heading"
     >
-      <div className="section-header">
-        <h2 id="running-prompts-heading" className="section-title">
-          ▶ 実行中のプロンプト ({runs.length})
+      <div className="dashboard-prompt-status__header">
+        <h2 id="prompt-status-heading" className="section-title">
+          プロンプト実行状況
         </h2>
-      </div>
-      <ul className="dashboard-running-section__list">
-        {runs.map((run) => (
-          <li
-            key={run.runId}
-            className="prompt-runs-row prompt-runs-row--running"
-          >
-            <span
-              className="prompt-runs-row__icon prompt-runs-row__icon--running"
-              role="img"
-              aria-label="実行中"
-            >
-              {RUN_STATUS_META.running.icon}
-            </span>
-            <div className="prompt-runs-row__body">
-              <div className="prompt-runs-row__title">
-                <span className="prompt-runs-row__project">
-                  {getProjectDisplayName(run.projectPath)}
-                </span>
-                <span className="prompt-runs-row__meta">
-                  <span>{formatElapsed(now - run.startedAt)}</span>
-                  <span>{run.permissionMode}</span>
-                </span>
-              </div>
-              <div className="prompt-runs-row__prompt" title={run.prompt}>
-                {run.prompt}
-              </div>
-              {run.lastActivity && (
-                <div className="prompt-runs-row__activity">
-                  {run.lastActivity}
-                </div>
-              )}
-            </div>
-            <div className="prompt-runs-row__actions">
-              <button
-                type="button"
-                className="prompt-runs-row__button"
-                onClick={() => onStop(run.runId)}
-              >
-                停止
-              </button>
-              {onOpen && (
-                <button
-                  type="button"
-                  className="prompt-runs-row__button prompt-runs-row__button--primary"
-                  onClick={() => onOpen(run.projectPath)}
+        <div className="dashboard-prompt-status__counts">
+          {(Object.keys(counts) as PromptRunStatus[]).map(
+            (status) =>
+              counts[status] > 0 && (
+                <span
+                  key={status}
+                  className={`dashboard-prompt-status__count dashboard-prompt-status__count--${status}`}
                 >
-                  開く
-                </button>
-              )}
-            </div>
-          </li>
+                  {RUN_STATUS_META[status].icon} {RUN_STATUS_META[status].label}{" "}
+                  {counts[status]}
+                </span>
+              ),
+          )}
+        </div>
+        {onOpenAll && (
+          <button
+            type="button"
+            className="dashboard-prompt-status__all"
+            onClick={onOpenAll}
+          >
+            すべて見る →
+          </button>
+        )}
+      </div>
+      <ul className="dashboard-prompt-status__list">
+        {visible.map((run) => (
+          <PromptRunRow
+            key={run.runId}
+            run={run}
+            now={now}
+            onOpen={() => onOpen?.(run.projectPath)}
+            onStop={() => onStop(run.runId)}
+          />
         ))}
       </ul>
+      {hiddenCount > 0 && onOpenAll && (
+        <button
+          type="button"
+          className="dashboard-prompt-status__more"
+          onClick={onOpenAll}
+        >
+          他 {hiddenCount} 件を Prompts タブで見る →
+        </button>
+      )}
     </section>
   );
 };
@@ -134,7 +160,9 @@ const ProjectCard: React.FC<{
   onClick: () => void;
   /** このプロジェクトの最新のプロンプト実行（無ければ null） */
   latestRun?: PromptRunInfo | null;
-}> = ({ project, onClick, latestRun }) => {
+  /** ~/.claude 上の最新セッション（アプリ外での作業も含む） */
+  latestSession?: ClaudeSession | null;
+}> = ({ project, onClick, latestRun, latestSession }) => {
   const projectName =
     project.project_path.split("/").pop() || project.project_path;
   const isActive = project.ide_info?.pid;
@@ -200,6 +228,29 @@ const ProjectCard: React.FC<{
         <div className="project-path-modern" title={project.project_path}>
           {project.project_path}
         </div>
+
+        {/* 直近のプロンプト実行（アプリ内）、無ければ最新セッションのプレビュー */}
+        {latestRun ? (
+          <div
+            className={`project-latest-prompt project-latest-prompt--${latestRun.status}`}
+            title={latestRun.prompt}
+          >
+            <span aria-hidden="true">
+              {RUN_STATUS_META[latestRun.status].icon}
+            </span>{" "}
+            {latestRun.prompt}
+          </div>
+        ) : latestSession?.latest_content_preview ? (
+          <div
+            className="project-latest-prompt project-latest-prompt--session"
+            title={latestSession.latest_content_preview}
+          >
+            <span aria-hidden="true">
+              {latestSession.is_processing ? "⏳" : "💬"}
+            </span>{" "}
+            {latestSession.latest_content_preview}
+          </div>
+        ) : null}
 
         <div className="project-metrics-modern">
           <div className="metric-grid">
@@ -292,11 +343,11 @@ const LoadingSkeleton: React.FC = () => (
 export const Dashboard: React.FC<DashboardProps> = ({
   onProjectClick,
   onOpenPromptRun,
+  onOpenPromptsTab,
 }) => {
   // Provider 配下でなければ null（既存テストの単体レンダリング等）
   const runsStore = usePromptRunsOptional();
-  const runningRuns =
-    runsStore?.runs.filter((run) => run.status === "running") ?? [];
+  const allRuns = runsStore?.runs ?? [];
 
   const handleStopRun = useCallback(
     (runId: string) => {
@@ -309,6 +360,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [sessions, setSessions] = useState<ClaudeSession[]>([]);
   const [showAllProjects, setShowAllProjects] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -317,18 +369,36 @@ export const Dashboard: React.FC<DashboardProps> = ({
     projects: boolean;
   }>({ stats: false, projects: false });
 
+  // プロジェクトごとの最新セッション（アプリ外での claude 実行も含む）
+  const latestSessionByProject = useMemo(() => {
+    const map = new Map<string, ClaudeSession>();
+    for (const session of sessions) {
+      const current = map.get(session.project_path);
+      if (
+        !current ||
+        new Date(session.file_modified_time).getTime() >
+          new Date(current.file_modified_time).getTime()
+      ) {
+        map.set(session.project_path, session);
+      }
+    }
+    return map;
+  }, [sessions]);
+
   const loadInitialData = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
 
-      const [statsData, projectsData] = await Promise.all([
+      const [statsData, projectsData, sessionsData] = await Promise.all([
         api.getSessionStats(),
         api.getProjectSummary(),
+        api.getAllSessions(),
       ]);
 
       setStats(statsData);
       setProjects(projectsData);
+      setSessions(sessionsData ?? []);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to load dashboard data",
@@ -357,8 +427,12 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
     try {
       setUpdating((prev) => ({ ...prev, projects: true }));
-      const projectsData = await api.getProjectSummary();
+      const [projectsData, sessionsData] = await Promise.all([
+        api.getProjectSummary(),
+        api.getAllSessions(),
+      ]);
       setProjects(projectsData);
+      setSessions(sessionsData ?? []);
     } catch (err) {
       console.error("Failed to update projects:", err);
     } finally {
@@ -422,10 +496,11 @@ export const Dashboard: React.FC<DashboardProps> = ({
         </div>
       </header>
 
-      <RunningPromptsSection
-        runs={runningRuns}
+      <PromptStatusSection
+        runs={allRuns}
         onOpen={onOpenPromptRun}
         onStop={handleStopRun}
+        onOpenAll={onOpenPromptsTab}
       />
 
       <section className="stats-section" aria-labelledby="stats-heading">
@@ -511,6 +586,9 @@ export const Dashboard: React.FC<DashboardProps> = ({
                   latestRun={
                     runsStore?.latestRunByProject.get(project.project_path) ??
                     null
+                  }
+                  latestSession={
+                    latestSessionByProject.get(project.project_path) ?? null
                   }
                   onClick={() => onProjectClick?.(project.project_path)}
                 />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { api } from "../api";
 import {
+  formatElapsed,
   RUN_STATUS_META,
   usePromptRunsOptional,
   type PromptRunInfo,
@@ -300,6 +301,34 @@ const QuickPromptComposer: React.FC<{
   );
 };
 
+/**
+ * カード上の実行中プログレス表示。
+ * プロンプト本文は実行中変化しないため、「いま何をしているか」
+ * （最後に観測したツール実行など）と経過時間を添えて進捗を可視化する。
+ */
+const CardRunProgress: React.FC<{ run: PromptRunInfo }> = ({ run }) => {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="project-run-progress">
+      <span
+        className="project-run-progress__activity"
+        title={run.lastActivity ?? undefined}
+      >
+        {run.lastActivity ?? "起動中…"}
+      </span>
+      <span className="project-run-progress__elapsed">
+        {formatElapsed(now - run.startedAt)}
+      </span>
+    </div>
+  );
+};
+
 const ProjectCard: React.FC<{
   project: ProjectSummary;
   onClick: () => void;
@@ -399,6 +428,9 @@ const ProjectCard: React.FC<{
             </span>
           </div>
         )}
+
+        {/* 実行中はプロンプト本文に加えて「いま何をしているか」と経過時間を出す */}
+        {latestRun?.status === "running" && <CardRunProgress run={latestRun} />}
 
         {/* アプリ外での作業も含む最新セッションのプレビュー（あれば） */}
         {!latestRun && latestSession?.latest_content_preview && (

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,8 +7,15 @@ import {
   type PromptRunStatus,
 } from "../contexts/PromptRunsContext";
 import { formatDateForContext } from "../utils/dateUtils";
+import { getProjectDisplayName } from "../utils/pathUtils";
 import { PromptRunRow } from "./PromptRunRow";
-import type { ClaudeSession, SessionStats, ProjectSummary } from "../types";
+import { SafeConfirmDialog } from "./SafeConfirmDialog";
+import type {
+  ClaudeSession,
+  PermissionMode,
+  SessionStats,
+  ProjectSummary,
+} from "../types";
 
 interface DashboardProps {
   onProjectClick?: (projectPath: string) => void;
@@ -158,6 +165,141 @@ const StatCard: React.FC<{
   );
 };
 
+/**
+ * カード上のクイック実行コンポーザー。
+ * プロジェクト画面へ移動せずに、Dashboard から直接プロンプトを送れる。
+ * 送信処理はストア（sendPrompt）が担うため、実行状況は自動的に
+ * カードの状態行・実行状況セクションに反映される。
+ */
+const QuickPromptComposer: React.FC<{
+  projectPath: string;
+  /** 送信。失敗時はエラーメッセージを返す（成功時は null） */
+  onSend: (
+    prompt: string,
+    permissionMode: PermissionMode,
+  ) => Promise<string | null>;
+}> = ({ projectPath, onSend }) => {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [mode, setMode] = useState<PermissionMode>("plan");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const doSend = useCallback(async () => {
+    const prompt = text.trim();
+    if (!prompt) return;
+    setSending(true);
+    setError(null);
+    try {
+      const failure = await onSend(prompt, mode);
+      if (failure) {
+        setError(failure);
+      } else {
+        setText("");
+        setOpen(false);
+      }
+    } finally {
+      setSending(false);
+    }
+  }, [text, mode, onSend]);
+
+  const handleSubmit = useCallback(() => {
+    if (!text.trim() || sending) return;
+    if (mode === "bypassPermissions") {
+      setConfirmOpen(true);
+      return;
+    }
+    void doSend();
+  }, [text, sending, mode, doSend]);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="quick-prompt__toggle"
+        aria-label={`${getProjectDisplayName(projectPath)} にプロンプトを実行`}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+      >
+        ▷ プロンプトを実行…
+      </button>
+    );
+  }
+
+  return (
+    // カード自体がクリック/キーボードで開くため、入力操作が伝播しないよう遮断する
+    // biome-ignore lint/a11y/noStaticElementInteractions: イベント伝播の遮断のみが目的
+    <div
+      className="quick-prompt"
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
+      <textarea
+        className="quick-prompt__textarea"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            handleSubmit();
+          }
+        }}
+        placeholder="Claude への指示…（Cmd/Ctrl + Enter で送信）"
+        rows={2}
+        // biome-ignore lint/a11y/noAutofocus: 「実行…」クリック直後の入力開始のため
+        autoFocus
+      />
+      <div className="quick-prompt__controls">
+        <select
+          aria-label="権限モード"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as PermissionMode)}
+        >
+          <option value="plan">読み取り専用</option>
+          <option value="acceptEdits">編集を自動承認</option>
+          <option value="bypassPermissions">全許可（危険）</option>
+        </select>
+        <button
+          type="button"
+          className="quick-prompt__button"
+          onClick={() => setOpen(false)}
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          className="quick-prompt__button quick-prompt__button--primary"
+          onClick={handleSubmit}
+          disabled={!text.trim() || sending}
+        >
+          送信
+        </button>
+      </div>
+      {error && (
+        <div className="quick-prompt__error" role="alert">
+          実行を開始できませんでした: {error}
+        </div>
+      )}
+      <SafeConfirmDialog
+        isOpen={confirmOpen}
+        title="全許可モードで実行しますか？"
+        message="「全許可（危険）」は Claude のすべてのツール実行を確認なしで許可します。ファイルの変更やコマンド実行が無条件に行われます。本当に実行しますか？"
+        confirmText="実行する"
+        cancelText="キャンセル"
+        variant="danger"
+        onConfirm={() => {
+          setConfirmOpen(false);
+          void doSend();
+        }}
+        onCancel={() => setConfirmOpen(false)}
+      />
+    </div>
+  );
+};
+
 const ProjectCard: React.FC<{
   project: ProjectSummary;
   onClick: () => void;
@@ -165,7 +307,12 @@ const ProjectCard: React.FC<{
   latestRun?: PromptRunInfo | null;
   /** ~/.claude 上の最新セッション（アプリ外での作業も含む） */
   latestSession?: ClaudeSession | null;
-}> = ({ project, onClick, latestRun, latestSession }) => {
+  /** クイック実行（Provider 配下でない場合は undefined で非表示） */
+  onQuickPrompt?: (
+    prompt: string,
+    permissionMode: PermissionMode,
+  ) => Promise<string | null>;
+}> = ({ project, onClick, latestRun, latestSession, onQuickPrompt }) => {
   const projectName =
     project.project_path.split("/").pop() || project.project_path;
   const isActive = project.ide_info?.pid;
@@ -224,9 +371,9 @@ const ProjectCard: React.FC<{
         </div>
 
         {/*
-          直近のプロンプト実行（アプリ内）、無ければ最新セッションのプレビュー。
-          状態バッジと本文行を 1 要素に統合し、状態は色ドット＋ラベルで示す
-          （タイトル横のバッジと二重に出さない — 冗長要素の削減）。
+          プロンプト実行状態の行（常時表示）。
+          実行が無いプロジェクトも「未実行」を明示し、
+          動かしていないことがひと目で分かるようにする。
         */}
         {latestRun ? (
           <div
@@ -244,7 +391,17 @@ const ProjectCard: React.FC<{
               {latestRun.prompt}
             </span>
           </div>
-        ) : latestSession?.latest_content_preview ? (
+        ) : (
+          <div className="project-latest-prompt project-latest-prompt--none">
+            <span className="run-status-dot" aria-hidden="true" />
+            <span className="project-latest-prompt__label">
+              プロンプト未実行
+            </span>
+          </div>
+        )}
+
+        {/* アプリ外での作業も含む最新セッションのプレビュー（あれば） */}
+        {!latestRun && latestSession?.latest_content_preview && (
           <div
             className="project-latest-prompt project-latest-prompt--session"
             title={latestSession.latest_content_preview}
@@ -259,7 +416,15 @@ const ProjectCard: React.FC<{
               {latestSession.latest_content_preview}
             </span>
           </div>
-        ) : null}
+        )}
+
+        {/* カードから直接プロンプトを実行（実行中は状態行が担うため非表示） */}
+        {onQuickPrompt && latestRun?.status !== "running" && (
+          <QuickPromptComposer
+            projectPath={project.project_path}
+            onSend={onQuickPrompt}
+          />
+        )}
 
         <div className="project-metrics-modern">
           <div className="metric-grid">
@@ -600,6 +765,16 @@ export const Dashboard: React.FC<DashboardProps> = ({
                     latestSessionByProject.get(project.project_path) ?? null
                   }
                   onClick={() => onProjectClick?.(project.project_path)}
+                  onQuickPrompt={
+                    runsStore
+                      ? (prompt, permissionMode) =>
+                          runsStore.sendPrompt(project.project_path, {
+                            prompt,
+                            permissionMode,
+                            model: null,
+                          })
+                      : undefined
+                  }
                 />
               ))}
             </div>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -87,8 +87,11 @@ const PromptStatusSection: React.FC<{
                   key={status}
                   className={`dashboard-prompt-status__count dashboard-prompt-status__count--${status}`}
                 >
-                  {RUN_STATUS_META[status].icon} {RUN_STATUS_META[status].label}{" "}
-                  {counts[status]}
+                  <span
+                    className={`run-status-dot run-status-dot--${status}`}
+                    aria-hidden="true"
+                  />
+                  {RUN_STATUS_META[status].label} {counts[status]}
                 </span>
               ),
           )}
@@ -213,15 +216,6 @@ const ProjectCard: React.FC<{
                 Active
               </span>
             )}
-            {latestRun && (
-              <span
-                className={`project-run-badge project-run-badge--${latestRun.status}`}
-                title={`プロンプト: ${latestRun.prompt}`}
-              >
-                {RUN_STATUS_META[latestRun.status].icon}{" "}
-                {RUN_STATUS_META[latestRun.status].label}
-              </span>
-            )}
           </div>
         </header>
 
@@ -229,26 +223,41 @@ const ProjectCard: React.FC<{
           {project.project_path}
         </div>
 
-        {/* 直近のプロンプト実行（アプリ内）、無ければ最新セッションのプレビュー */}
+        {/*
+          直近のプロンプト実行（アプリ内）、無ければ最新セッションのプレビュー。
+          状態バッジと本文行を 1 要素に統合し、状態は色ドット＋ラベルで示す
+          （タイトル横のバッジと二重に出さない — 冗長要素の削減）。
+        */}
         {latestRun ? (
           <div
             className={`project-latest-prompt project-latest-prompt--${latestRun.status}`}
-            title={latestRun.prompt}
+            title={`${RUN_STATUS_META[latestRun.status].label}: ${latestRun.prompt}`}
           >
-            <span aria-hidden="true">
-              {RUN_STATUS_META[latestRun.status].icon}
-            </span>{" "}
-            {latestRun.prompt}
+            <span
+              className={`run-status-dot run-status-dot--${latestRun.status}`}
+              aria-hidden="true"
+            />
+            <span className="project-latest-prompt__label">
+              {RUN_STATUS_META[latestRun.status].label}
+            </span>
+            <span className="project-latest-prompt__text">
+              {latestRun.prompt}
+            </span>
           </div>
         ) : latestSession?.latest_content_preview ? (
           <div
             className="project-latest-prompt project-latest-prompt--session"
             title={latestSession.latest_content_preview}
           >
-            <span aria-hidden="true">
-              {latestSession.is_processing ? "⏳" : "💬"}
-            </span>{" "}
-            {latestSession.latest_content_preview}
+            {latestSession.is_processing && (
+              <span
+                className="run-status-dot run-status-dot--running"
+                aria-hidden="true"
+              />
+            )}
+            <span className="project-latest-prompt__text">
+              {latestSession.latest_content_preview}
+            </span>
           </div>
         ) : null}
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,6 +16,9 @@ interface DashboardProps {
   onOpenPromptRun?: (projectPath: string) => void;
 }
 
+/** Recent Projects を折りたたみ表示するときの件数 */
+const COLLAPSED_PROJECT_COUNT = 6;
+
 /** Dashboard 上部の「実行中のプロンプト」セクション */
 const RunningPromptsSection: React.FC<{
   runs: PromptRunInfo[];
@@ -306,6 +309,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
 
   const [stats, setStats] = useState<SessionStats | null>(null);
   const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [showAllProjects, setShowAllProjects] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [updating, setUpdating] = useState<{
@@ -493,21 +497,40 @@ export const Dashboard: React.FC<DashboardProps> = ({
             description="No Claude Code projects have been created yet"
           />
         ) : (
-          <div
-            className={`projects-grid ${updating.projects ? "updating" : ""}`}
-          >
-            {projects.slice(0, 6).map((project) => (
-              <ProjectCard
-                key={project.project_path}
-                project={project}
-                latestRun={
-                  runsStore?.latestRunByProject.get(project.project_path) ??
-                  null
-                }
-                onClick={() => onProjectClick?.(project.project_path)}
-              />
-            ))}
-          </div>
+          <>
+            <div
+              className={`projects-grid ${updating.projects ? "updating" : ""}`}
+            >
+              {(showAllProjects
+                ? projects
+                : projects.slice(0, COLLAPSED_PROJECT_COUNT)
+              ).map((project) => (
+                <ProjectCard
+                  key={project.project_path}
+                  project={project}
+                  latestRun={
+                    runsStore?.latestRunByProject.get(project.project_path) ??
+                    null
+                  }
+                  onClick={() => onProjectClick?.(project.project_path)}
+                />
+              ))}
+            </div>
+            {projects.length > COLLAPSED_PROJECT_COUNT && (
+              <div className="projects-show-all">
+                <button
+                  type="button"
+                  className="show-all-projects-button"
+                  aria-expanded={showAllProjects}
+                  onClick={() => setShowAllProjects((prev) => !prev)}
+                >
+                  {showAllProjects
+                    ? "Show less"
+                    : `Show all ${projects.length} projects`}
+                </button>
+              </div>
+            )}
+          </>
         )}
       </section>
     </div>

--- a/src/components/PromptRunRow.tsx
+++ b/src/components/PromptRunRow.tsx
@@ -1,10 +1,17 @@
 /**
  * プロンプト実行 1 件分の行表示。
  * Prompts タブ（PromptsOverview）と Dashboard の実行状況セクションで共用する。
+ *
+ * レイアウトは可読性の研究に基づく:
+ * - F 字型走査に合わせ、左端に固定幅の状態ピル（色＋ラベル）を縦に揃える
+ * - 主役はプロンプト本文（太字・最大 60ch で省略）。メタ情報は 2 行目に淡色で降格
+ * - 右端に相対時刻（「3分前」）。正確な時刻は title で補う
+ * - 権限モードは既定（plan）では表示せず、bypassPermissions のときだけ警告する
  */
 import React from "react";
 import {
   formatElapsed,
+  formatRelativeTime,
   RUN_STATUS_META,
   type PromptRunInfo,
 } from "../contexts/PromptRunsContext";
@@ -12,7 +19,7 @@ import { getProjectDisplayName } from "../utils/pathUtils";
 
 interface PromptRunRowProps {
   run: PromptRunInfo;
-  /** 実行中の経過時間計算に使う現在時刻（呼び出し側で 1 秒ごとに更新） */
+  /** 実行中の経過時間・相対時刻の計算に使う現在時刻（呼び出し側で 1 秒ごとに更新） */
   now: number;
   onOpen: () => void;
   onStop: () => void;
@@ -21,46 +28,55 @@ interface PromptRunRowProps {
 export const PromptRunRow = React.memo<PromptRunRowProps>(
   ({ run, now, onOpen, onStop }) => {
     const meta = RUN_STATUS_META[run.status];
-    const elapsed =
-      run.status === "running"
-        ? formatElapsed(now - run.startedAt)
-        : run.durationMs !== null
-          ? formatElapsed(run.durationMs)
-          : null;
+    const isRunning = run.status === "running";
+
+    // 「いつ」: 実行中は経過時間、終了後は終了時点からの相対時刻
+    const whenTimestamp = run.finishedAt ?? run.startedAt;
+    const when = isRunning
+      ? `${formatElapsed(now - run.startedAt)} 経過`
+      : formatRelativeTime(whenTimestamp, now);
+    const whenTitle = new Date(whenTimestamp).toLocaleString();
 
     return (
       <li className={`prompt-runs-row prompt-runs-row--${run.status}`}>
         <span
-          className={`prompt-runs-row__icon prompt-runs-row__icon--${run.status}`}
-          role="img"
+          className={`run-status-pill run-status-pill--${run.status}`}
           aria-label={meta.label}
         >
-          {meta.icon}
+          <span className="run-status-pill__dot" aria-hidden="true" />
+          {meta.label}
         </span>
         <div className="prompt-runs-row__body">
-          <div className="prompt-runs-row__title">
+          <div className="prompt-runs-row__primary">
+            <span className="prompt-runs-row__prompt" title={run.prompt}>
+              {run.prompt}
+            </span>
+            <time className="prompt-runs-row__when" title={whenTitle}>
+              {when}
+            </time>
+          </div>
+          <div className="prompt-runs-row__secondary">
             <span className="prompt-runs-row__project">
               {getProjectDisplayName(run.projectPath)}
             </span>
-            <span className="prompt-runs-row__meta">
-              {elapsed && <span>{elapsed}</span>}
-              {run.numTurns !== null && <span>{run.numTurns} turns</span>}
-              {run.costUsd !== null && <span>${run.costUsd.toFixed(4)}</span>}
-              {run.status === "running" && <span>{run.permissionMode}</span>}
-              {run.status === "failed" && run.exitCode !== null && (
-                <span>終了コード {run.exitCode}</span>
-              )}
-            </span>
+            {!isRunning && run.durationMs !== null && (
+              <span>{formatElapsed(run.durationMs)}</span>
+            )}
+            {run.numTurns !== null && <span>{run.numTurns} turns</span>}
+            {run.costUsd !== null && <span>${run.costUsd.toFixed(2)}</span>}
+            {run.status === "failed" && run.exitCode !== null && (
+              <span>終了コード {run.exitCode}</span>
+            )}
+            {run.permissionMode === "bypassPermissions" && (
+              <span className="prompt-runs-row__danger-mode">全許可</span>
+            )}
           </div>
-          <div className="prompt-runs-row__prompt" title={run.prompt}>
-            {run.prompt}
-          </div>
-          {run.status === "running" && run.lastActivity && (
+          {isRunning && run.lastActivity && (
             <div className="prompt-runs-row__activity">{run.lastActivity}</div>
           )}
         </div>
         <div className="prompt-runs-row__actions">
-          {run.status === "running" && (
+          {isRunning && (
             <button
               type="button"
               className="prompt-runs-row__button"

--- a/src/components/PromptRunRow.tsx
+++ b/src/components/PromptRunRow.tsx
@@ -1,0 +1,84 @@
+/**
+ * プロンプト実行 1 件分の行表示。
+ * Prompts タブ（PromptsOverview）と Dashboard の実行状況セクションで共用する。
+ */
+import React from "react";
+import {
+  formatElapsed,
+  RUN_STATUS_META,
+  type PromptRunInfo,
+} from "../contexts/PromptRunsContext";
+import { getProjectDisplayName } from "../utils/pathUtils";
+
+interface PromptRunRowProps {
+  run: PromptRunInfo;
+  /** 実行中の経過時間計算に使う現在時刻（呼び出し側で 1 秒ごとに更新） */
+  now: number;
+  onOpen: () => void;
+  onStop: () => void;
+}
+
+export const PromptRunRow = React.memo<PromptRunRowProps>(
+  ({ run, now, onOpen, onStop }) => {
+    const meta = RUN_STATUS_META[run.status];
+    const elapsed =
+      run.status === "running"
+        ? formatElapsed(now - run.startedAt)
+        : run.durationMs !== null
+          ? formatElapsed(run.durationMs)
+          : null;
+
+    return (
+      <li className={`prompt-runs-row prompt-runs-row--${run.status}`}>
+        <span
+          className={`prompt-runs-row__icon prompt-runs-row__icon--${run.status}`}
+          role="img"
+          aria-label={meta.label}
+        >
+          {meta.icon}
+        </span>
+        <div className="prompt-runs-row__body">
+          <div className="prompt-runs-row__title">
+            <span className="prompt-runs-row__project">
+              {getProjectDisplayName(run.projectPath)}
+            </span>
+            <span className="prompt-runs-row__meta">
+              {elapsed && <span>{elapsed}</span>}
+              {run.numTurns !== null && <span>{run.numTurns} turns</span>}
+              {run.costUsd !== null && <span>${run.costUsd.toFixed(4)}</span>}
+              {run.status === "running" && <span>{run.permissionMode}</span>}
+              {run.status === "failed" && run.exitCode !== null && (
+                <span>終了コード {run.exitCode}</span>
+              )}
+            </span>
+          </div>
+          <div className="prompt-runs-row__prompt" title={run.prompt}>
+            {run.prompt}
+          </div>
+          {run.status === "running" && run.lastActivity && (
+            <div className="prompt-runs-row__activity">{run.lastActivity}</div>
+          )}
+        </div>
+        <div className="prompt-runs-row__actions">
+          {run.status === "running" && (
+            <button
+              type="button"
+              className="prompt-runs-row__button"
+              onClick={onStop}
+            >
+              停止
+            </button>
+          )}
+          <button
+            type="button"
+            className="prompt-runs-row__button prompt-runs-row__button--primary"
+            onClick={onOpen}
+          >
+            開く
+          </button>
+        </div>
+      </li>
+    );
+  },
+);
+PromptRunRow.displayName = "PromptRunRow";

--- a/src/components/PromptsOverview.tsx
+++ b/src/components/PromptsOverview.tsx
@@ -6,13 +6,11 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  formatElapsed,
   RUN_STATUS_META,
   usePromptRuns,
-  type PromptRunInfo,
   type PromptRunStatus,
 } from "../contexts/PromptRunsContext";
-import { getProjectDisplayName } from "../utils/pathUtils";
+import { PromptRunRow } from "./PromptRunRow";
 
 interface PromptsOverviewProps {
   onOpenProject: (projectPath: string) => void;
@@ -27,72 +25,6 @@ const FILTERS: { key: Filter; label: string }[] = [
   { key: "failed", label: "失敗" },
   { key: "stopped", label: "停止" },
 ];
-
-const RunRow: React.FC<{
-  run: PromptRunInfo;
-  now: number;
-  onOpen: () => void;
-  onStop: () => void;
-}> = ({ run, now, onOpen, onStop }) => {
-  const meta = RUN_STATUS_META[run.status];
-  const elapsed =
-    run.status === "running"
-      ? formatElapsed(now - run.startedAt)
-      : run.durationMs !== null
-        ? formatElapsed(run.durationMs)
-        : null;
-
-  return (
-    <li className={`prompt-runs-row prompt-runs-row--${run.status}`}>
-      <span
-        className={`prompt-runs-row__icon prompt-runs-row__icon--${run.status}`}
-        role="img"
-        aria-label={meta.label}
-      >
-        {meta.icon}
-      </span>
-      <div className="prompt-runs-row__body">
-        <div className="prompt-runs-row__title">
-          <span className="prompt-runs-row__project">
-            {getProjectDisplayName(run.projectPath)}
-          </span>
-          <span className="prompt-runs-row__meta">
-            {elapsed && <span>{elapsed}</span>}
-            {run.numTurns !== null && <span>{run.numTurns} turns</span>}
-            {run.costUsd !== null && <span>${run.costUsd.toFixed(4)}</span>}
-            {run.status === "failed" && run.exitCode !== null && (
-              <span>終了コード {run.exitCode}</span>
-            )}
-          </span>
-        </div>
-        <div className="prompt-runs-row__prompt" title={run.prompt}>
-          {run.prompt}
-        </div>
-        {run.status === "running" && run.lastActivity && (
-          <div className="prompt-runs-row__activity">{run.lastActivity}</div>
-        )}
-      </div>
-      <div className="prompt-runs-row__actions">
-        {run.status === "running" && (
-          <button
-            type="button"
-            className="prompt-runs-row__button"
-            onClick={onStop}
-          >
-            停止
-          </button>
-        )}
-        <button
-          type="button"
-          className="prompt-runs-row__button prompt-runs-row__button--primary"
-          onClick={onOpen}
-        >
-          開く
-        </button>
-      </div>
-    </li>
-  );
-};
 
 export const PromptsOverview: React.FC<PromptsOverviewProps> = ({
   onOpenProject,
@@ -179,7 +111,7 @@ export const PromptsOverview: React.FC<PromptsOverviewProps> = ({
       ) : (
         <ul className="prompts-overview__list">
           {visibleRuns.map((run) => (
-            <RunRow
+            <PromptRunRow
               key={run.runId}
               run={run}
               now={now}

--- a/src/components/PromptsOverview.tsx
+++ b/src/components/PromptsOverview.tsx
@@ -6,7 +6,6 @@
  */
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  RUN_STATUS_META,
   usePromptRuns,
   type PromptRunStatus,
 } from "../contexts/PromptRunsContext";
@@ -92,7 +91,10 @@ export const PromptsOverview: React.FC<PromptsOverviewProps> = ({
             onClick={() => setFilter(key)}
           >
             {key !== "all" && (
-              <span aria-hidden="true">{RUN_STATUS_META[key].icon} </span>
+              <span
+                className={`run-status-dot run-status-dot--${key}`}
+                aria-hidden="true"
+              />
             )}
             {label}
             <span className="prompts-overview__filter-count">

--- a/src/components/__tests__/DashboardPromptStatus.test.tsx
+++ b/src/components/__tests__/DashboardPromptStatus.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Dashboard の「プロンプト実行状況」セクションと
+ * プロジェクトカードの直近アクティビティ行のテスト。
+ */
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import React from "react";
+import { Dashboard } from "../Dashboard";
+import {
+  PromptRunsProvider,
+  usePromptRuns,
+  type RegisterRunMeta,
+} from "../../contexts/PromptRunsContext";
+import { api } from "../../api";
+import type { PromptRunEvent } from "../../types";
+
+vi.mock("../../api");
+const mockApi = vi.mocked(api);
+
+let handlers: Set<(event: PromptRunEvent) => void> = new Set();
+
+const emit = (event: PromptRunEvent): void => {
+  act(() => {
+    for (const handler of handlers) handler(event);
+  });
+};
+
+let registerRun: ((runId: string, meta: RegisterRunMeta) => void) | null = null;
+
+const Harness: React.FC = () => {
+  const store = usePromptRuns();
+  registerRun = store.registerRun;
+  return null;
+};
+
+const register = (runId: string, projectPath: string, prompt: string) => {
+  act(() => {
+    registerRun?.(runId, {
+      projectPath,
+      prompt,
+      permissionMode: "plan",
+      model: null,
+    });
+  });
+};
+
+const STATS = {
+  total_sessions: 1,
+  total_messages: 1,
+  total_commands: 0,
+  active_projects: 1,
+  pending_todos: 0,
+};
+
+const PROJECTS = [
+  {
+    project_path: "/Users/john/projects/alpha",
+    session_count: 1,
+    last_activity: "2026-08-01T10:00:00Z",
+    total_messages: 1,
+    active_todos: 0,
+  },
+];
+
+describe("Dashboard prompt status board", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = new Set();
+    registerRun = null;
+
+    mockApi.getSessionStats.mockResolvedValue(STATS);
+    mockApi.getProjectSummary.mockResolvedValue(PROJECTS);
+    mockApi.getAllSessions.mockResolvedValue([]);
+    mockApi.stopPromptRun.mockResolvedValue(undefined);
+    mockApi.onPromptRunEvent.mockImplementation(async (handler) => {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    });
+  });
+
+  const renderDashboard = (
+    props: Partial<React.ComponentProps<typeof Dashboard>> = {},
+  ) =>
+    render(
+      <PromptRunsProvider>
+        <Harness />
+        <Dashboard {...props} />
+      </PromptRunsProvider>,
+    );
+
+  it("実行が無いときはセクションを表示しない", async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("プロンプト実行状況")).not.toBeInTheDocument();
+  });
+
+  it("実行中・完了が件数チップ付きで一覧表示される", async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+
+    register("run-1", "/Users/john/projects/alpha", "テストを追加して");
+    register("run-2", "/Users/john/projects/beta", "READMEを更新して");
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+
+    expect(screen.getByText("プロンプト実行状況")).toBeInTheDocument();
+    expect(screen.getByText(/実行中\s*1/)).toBeInTheDocument();
+    expect(screen.getByText(/完了\s*1/)).toBeInTheDocument();
+    // alpha は PROJECTS にあるためカードにも表示され、複数一致になりうる
+    expect(screen.getAllByText("テストを追加して").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("READMEを更新して").length).toBeGreaterThan(0);
+  });
+
+  it("すべて見るで onOpenPromptsTab が呼ばれる", async () => {
+    const onOpenPromptsTab = vi.fn();
+    renderDashboard({ onOpenPromptsTab });
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+
+    register("run-1", "/Users/john/projects/alpha", "テストを追加して");
+
+    fireEvent.click(screen.getByRole("button", { name: "すべて見る →" }));
+    expect(onOpenPromptsTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("プロジェクトカードに直近の実行プロンプトが表示される", async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+
+    register("run-1", "/Users/john/projects/alpha", "カードに出るはず");
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+
+    // セクションの行とカードの行の 2 箇所に出る
+    expect(
+      screen.getAllByText("カードに出るはず").length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it("実行が無いプロジェクトのカードには最新セッションのプレビューが出る", async () => {
+    mockApi.getAllSessions.mockResolvedValue([
+      {
+        session_id: "s-1",
+        project_path: "/Users/john/projects/alpha",
+        timestamp: "2026-08-01T10:00:00Z",
+        message_count: 3,
+        is_processing: false,
+        file_modified_time: "2026-08-01T10:30:00Z",
+        latest_content_preview: "最後にやり取りした内容のプレビュー",
+      },
+    ]);
+
+    renderDashboard();
+    await waitFor(() => {
+      expect(
+        screen.getByText("最後にやり取りした内容のプレビュー"),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/DashboardPromptStatus.test.tsx
+++ b/src/components/__tests__/DashboardPromptStatus.test.tsx
@@ -122,6 +122,46 @@ describe("Dashboard prompt status board", () => {
     expect(screen.getAllByText("READMEを更新して").length).toBeGreaterThan(0);
   });
 
+  it("実行中のカードには進捗（活動と経過時間）が表示される", async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+
+    register("run-1", "/Users/john/projects/alpha", "テストを追加して");
+
+    // 活動がまだ無い間は起動中と出る
+    expect(screen.getByText("起動中…")).toBeInTheDocument();
+
+    // ツール実行イベントが届くと「いま何をしているか」に置き換わる
+    emit({
+      run_id: "run-1",
+      kind: "message",
+      payload: {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "Read",
+              input: { file_path: "src/api.ts" },
+            },
+          ],
+        },
+      },
+    });
+
+    // セクションの行とカードの進捗行の両方に出る
+    expect(screen.getAllByText("⚙ Read src/api.ts").length).toBeGreaterThan(1);
+
+    // 完了すると進捗表示は消える
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+    expect(screen.queryByText("起動中…")).not.toBeInTheDocument();
+    expect(screen.queryByText("⚙ Read src/api.ts")).not.toBeInTheDocument();
+  });
+
   it("すべて見るで onOpenPromptsTab が呼ばれる", async () => {
     const onOpenPromptsTab = vi.fn();
     renderDashboard({ onOpenPromptsTab });

--- a/src/components/__tests__/DashboardPromptStatus.test.tsx
+++ b/src/components/__tests__/DashboardPromptStatus.test.tsx
@@ -170,4 +170,75 @@ describe("Dashboard prompt status board", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("実行が無いプロジェクトのカードには「プロンプト未実行」が出る", async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+    expect(screen.getByText("プロンプト未実行")).toBeInTheDocument();
+  });
+
+  it("カードのクイック実行からプロンプトを送信できる", async () => {
+    mockApi.startPromptRun.mockResolvedValue("run-quick");
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+
+    // 「▷ プロンプトを実行…」を開いて送信
+    fireEvent.click(
+      screen.getByRole("button", { name: "alpha にプロンプトを実行" }),
+    );
+    const textarea = screen.getByPlaceholderText(
+      "Claude への指示…（Cmd/Ctrl + Enter で送信）",
+    );
+    fireEvent.change(textarea, { target: { value: "カードから実行" } });
+    fireEvent.click(screen.getByRole("button", { name: "送信" }));
+
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledWith({
+        projectPath: "/Users/john/projects/alpha",
+        prompt: "カードから実行",
+        permissionMode: "plan",
+        resumeSessionId: null,
+        model: null,
+      });
+    });
+
+    // 送信後は実行中としてカード・セクションに反映される
+    expect(screen.getByText("プロンプト実行状況")).toBeInTheDocument();
+    expect(screen.getAllByText("カードから実行").length).toBeGreaterThanOrEqual(
+      1,
+    );
+    // 実行中のカードにはコンポーザーを出さない
+    expect(
+      screen.queryByRole("button", { name: "alpha にプロンプトを実行" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("クイック実行の起動失敗はカード内にエラー表示される", async () => {
+    mockApi.startPromptRun.mockRejectedValue(new Error("spawn failed"));
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText("Recent Projects")).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "alpha にプロンプトを実行" }),
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Claude への指示…（Cmd/Ctrl + Enter で送信）",
+      ),
+      { target: { value: "失敗するはず" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "送信" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/実行を開始できませんでした: spawn failed/),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/__tests__/ProjectScreen.test.tsx
+++ b/src/components/__tests__/ProjectScreen.test.tsx
@@ -119,10 +119,14 @@ describe("ProjectScreen", () => {
       ).toBeInTheDocument();
     });
 
-    // Verify that the empty directory message is shown since we mocked an empty directory
-    expect(
-      screen.getByText(".claude directory exists but is empty."),
-    ).toBeInTheDocument();
+    // Verify that the empty directory message is shown since we mocked an empty directory.
+    // ディレクトリ情報は非同期取得のため、見出し表示より遅れて描画される
+    // （遅い CI ランナーで顕在化するレース）。waitFor で解決を待つ。
+    await waitFor(() => {
+      expect(
+        screen.getByText(".claude directory exists but is empty."),
+      ).toBeInTheDocument();
+    });
   });
 
   it("should render sessions list", async () => {

--- a/src/contexts/PromptRunsContext.tsx
+++ b/src/contexts/PromptRunsContext.tsx
@@ -111,7 +111,10 @@ interface PromptRunsContextValue {
   registerRun: (runId: string, meta: RegisterRunMeta) => void;
   stopRun: (runId: string) => Promise<void>;
   /** プロンプトを送信する（会話へのエントリ追加〜実行登録まで担う） */
-  sendPrompt: (projectPath: string, params: SendPromptParams) => Promise<void>;
+  sendPrompt: (
+    projectPath: string,
+    params: SendPromptParams,
+  ) => Promise<string | null>;
   /** 会話ログをクリアして新しい会話を始める */
   resetConversation: (projectPath: string) => void;
 }
@@ -444,11 +447,18 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
    * プロンプト送信の一連の流れを担う:
    * ユーザー発言の追加 → CLI 起動 → 実行の登録（バッファ済みイベントの反映）。
    * 失敗時はエラー行を会話に追加して実行中フラグを下ろす。
+   *
+   * @returns 起動に失敗した場合はエラーメッセージ、成功時は null。
+   *   Dashboard のクイック実行など、会話ビューの外から呼ぶ場合の
+   *   フィードバックに使う。
    */
   const sendPrompt = useCallback(
-    async (projectPath: string, params: SendPromptParams) => {
+    async (
+      projectPath: string,
+      params: SendPromptParams,
+    ): Promise<string | null> => {
       const text = params.prompt.trim();
-      if (!text) return;
+      if (!text) return null;
 
       const conversations = conversationsRef.current;
       const before = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
@@ -479,7 +489,9 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
           permissionMode: params.permissionMode,
           model: params.model,
         });
+        return null;
       } catch (error: unknown) {
+        const message = toErrorMessage(error);
         const current = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
         conversations.set(projectPath, {
           ...current,
@@ -490,11 +502,12 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
             {
               id: nextEntryId(),
               kind: "error",
-              text: `実行を開始できませんでした: ${toErrorMessage(error)}`,
+              text: `実行を開始できませんでした: ${message}`,
             },
           ],
         });
         bump();
+        return message;
       }
     },
     [bump, registerRun],

--- a/src/contexts/PromptRunsContext.tsx
+++ b/src/contexts/PromptRunsContext.tsx
@@ -315,6 +315,143 @@ function applyConversationEvent(
   }
 }
 
+// ---------------------------------------------------------------------------
+// 永続化（localStorage）
+// アプリを再起動しても、実行履歴・会話ログ・セッションの紐付けが残り、
+// 過去の会話の続きから再開（--resume）できるようにする。
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "ccm-prompt-runs-v1";
+/** 保存する会話エントリの上限（プロジェクトごと・新しい順に残す） */
+const PERSIST_ENTRIES_LIMIT = 100;
+/** 保存する tool_result 本文の上限（表示上限と同じ） */
+const PERSIST_TOOL_RESULT_LIMIT = 4000;
+/** localStorage へ書き込む JSON のおおよその上限（バイト） */
+const PERSIST_SIZE_LIMIT = 3_000_000;
+
+interface PersistedConversation {
+  sessionId: string | null;
+  entries: ConversationEntry[];
+}
+
+interface PersistedState {
+  runs: PromptRunInfo[];
+  conversations: Record<string, PersistedConversation>;
+}
+
+/** 保存用にエントリを軽量化する（巨大な tool_result を刈り込む） */
+function slimEntry(entry: ConversationEntry): ConversationEntry {
+  if (entry.kind !== "block" || entry.block.type !== "tool_result") {
+    return entry;
+  }
+  const content = entry.block.content;
+  if (
+    typeof content === "string" &&
+    content.length > PERSIST_TOOL_RESULT_LIMIT
+  ) {
+    return {
+      ...entry,
+      block: {
+        ...entry.block,
+        content: `${content.slice(0, PERSIST_TOOL_RESULT_LIMIT)}…（保存時に省略）`,
+      },
+    };
+  }
+  return entry;
+}
+
+function buildPersistedState(
+  runs: Map<string, PromptRunInfo>,
+  conversations: Map<string, PromptConversation>,
+): string | null {
+  try {
+    const state: PersistedState = {
+      runs: [...runs.values()],
+      conversations: Object.fromEntries(
+        [...conversations.entries()].map(([projectPath, conversation]) => [
+          projectPath,
+          {
+            sessionId: conversation.sessionId,
+            entries: conversation.entries
+              .slice(-PERSIST_ENTRIES_LIMIT)
+              .map(slimEntry),
+          },
+        ]),
+      ),
+    };
+    let json = JSON.stringify(state);
+    if (json.length > PERSIST_SIZE_LIMIT) {
+      // 大きすぎる場合は会話ログを落とし、履歴と紐付けだけ残す
+      for (const key of Object.keys(state.conversations)) {
+        state.conversations[key].entries = [];
+      }
+      json = JSON.stringify(state);
+    }
+    return json;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 保存済み状態を読み込む。
+ * 前回終了時に実行中だった run は、アプリ終了と同時に CLI プロセスも
+ * 終了している（kill_on_drop）ため「停止」として復元する。
+ */
+function hydrateFromStorage(): {
+  runs: Map<string, PromptRunInfo>;
+  conversations: Map<string, PromptConversation>;
+} {
+  const runs = new Map<string, PromptRunInfo>();
+  const conversations = new Map<string, PromptConversation>();
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { runs, conversations };
+    const state = JSON.parse(raw) as PersistedState;
+
+    for (const run of state.runs ?? []) {
+      if (!run?.runId || !run.projectPath) continue;
+      runs.set(
+        run.runId,
+        run.status === "running"
+          ? {
+              ...run,
+              status: "stopped",
+              finishedAt: run.finishedAt ?? Date.now(),
+            }
+          : run,
+      );
+    }
+
+    const interruptedProjects = new Set(
+      [...runs.values()]
+        .filter((r) => r.status === "stopped" && r.exitCode === null)
+        .map((r) => r.projectPath),
+    );
+
+    for (const [projectPath, persisted] of Object.entries(
+      state.conversations ?? {},
+    )) {
+      const entries = [...(persisted.entries ?? [])];
+      if (interruptedProjects.has(projectPath)) {
+        entries.push({
+          id: nextEntryId(),
+          kind: "error",
+          text: "アプリ終了により実行が中断されました",
+        });
+      }
+      conversations.set(projectPath, {
+        ...EMPTY_CONVERSATION,
+        sessionId: persisted.sessionId ?? null,
+        entries,
+      });
+    }
+  } catch {
+    // 壊れた保存データは無視して空から始める
+  }
+  return { runs, conversations };
+}
+
 export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -324,6 +461,28 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
   const conversationsRef = useRef<Map<string, PromptConversation>>(new Map());
   const [version, setVersion] = useState(0);
   const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  // 初回レンダリング時に保存済み状態を復元する（マウントごとに 1 回）
+  const hydratedRef = useRef(false);
+  if (!hydratedRef.current) {
+    hydratedRef.current = true;
+    const { runs, conversations } = hydrateFromStorage();
+    runsRef.current = runs;
+    conversationsRef.current = conversations;
+  }
+
+  // 変更のたびに保存する（軽量 JSON。失敗しても機能には影響させない）
+  useEffect(() => {
+    if (version === 0) return;
+    const json = buildPersistedState(runsRef.current, conversationsRef.current);
+    if (json !== null) {
+      try {
+        localStorage.setItem(STORAGE_KEY, json);
+      } catch {
+        // 容量超過などは無視（次回の書き込みで再試行される）
+      }
+    }
+  }, [version]);
 
   // registerRun 前に届いたイベントの一時バッファ（run_id ごと・受信順）
   const pendingRef = useRef<Map<string, PromptRunEvent[]>>(new Map());

--- a/src/contexts/PromptRunsContext.tsx
+++ b/src/contexts/PromptRunsContext.tsx
@@ -598,12 +598,31 @@ export function formatElapsed(ms: number): string {
   return `${minutes}m${String(seconds).padStart(2, "0")}s`;
 }
 
-export const RUN_STATUS_META: Record<
-  PromptRunStatus,
-  { icon: string; label: string }
-> = {
-  running: { icon: "⏳", label: "実行中" },
-  completed: { icon: "✅", label: "完了" },
-  failed: { icon: "❌", label: "失敗" },
-  stopped: { icon: "⏹", label: "停止" },
+/**
+ * 相対時刻の短縮表記（「3分前」）。
+ * アクティビティフィードの研究より、正確な時刻ではなく
+ * 「どれくらい前か」の大まかな手掛かりが最も速く読み取れる。
+ * 正確な時刻はツールチップ（title 属性）で補う。
+ */
+export function formatRelativeTime(timestamp: number, now: number): string {
+  const diffSeconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (diffSeconds < 60) return "たった今";
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes}分前`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}時間前`;
+  return `${Math.floor(diffHours / 24)}日前`;
+}
+
+/**
+ * 状態の表示ラベル。
+ * 状態は「色ドット＋文字ラベル」で表現する（色・形・ラベルの 3 要素、
+ * WCAG 1.4.1 / IBM Carbon の状態インジケータ指針に従う）。
+ * 絵文字は環境依存で見た目が変わり、走査時のノイズにもなるため使わない。
+ */
+export const RUN_STATUS_META: Record<PromptRunStatus, { label: string }> = {
+  running: { label: "実行中" },
+  completed: { label: "完了" },
+  failed: { label: "失敗" },
+  stopped: { label: "停止" },
 };

--- a/src/contexts/__tests__/PromptRunsPersistence.test.tsx
+++ b/src/contexts/__tests__/PromptRunsPersistence.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * PromptRunsContext の永続化（localStorage）のテスト。
+ * アプリ再起動（Provider の破棄と再マウント）をまたいで、
+ * 実行履歴・会話ログ・セッション紐付けが復元されることを確認する。
+ */
+import { render, act } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import React from "react";
+import { PromptRunsProvider, usePromptRuns } from "../PromptRunsContext";
+import { api } from "../../api";
+import type { PromptRunEvent } from "../../types";
+
+vi.mock("../../api");
+const mockApi = vi.mocked(api);
+
+let handlers: Set<(event: PromptRunEvent) => void> = new Set();
+
+const emit = (event: PromptRunEvent): void => {
+  act(() => {
+    for (const handler of handlers) handler(event);
+  });
+};
+
+/** Provider 配下のストアを外から観測・操作するためのハーネス */
+let store: ReturnType<typeof usePromptRuns> | null = null;
+
+/** 再マウント後の store を型を保ったまま取得する（未マウントなら失敗） */
+const getStore = (): ReturnType<typeof usePromptRuns> => {
+  if (!store) throw new Error("store is not mounted");
+  return store;
+};
+
+const Harness: React.FC = () => {
+  store = usePromptRuns();
+  return null;
+};
+
+const mountProvider = () =>
+  render(
+    <PromptRunsProvider>
+      <Harness />
+    </PromptRunsProvider>,
+  );
+
+describe("PromptRuns persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = new Set();
+    store = null;
+
+    mockApi.startPromptRun.mockResolvedValue("run-1");
+    mockApi.onPromptRunEvent.mockImplementation(async (handler) => {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    });
+  });
+
+  it("実行履歴・会話・セッション紐付けが再マウント後も復元される", async () => {
+    const first = mountProvider();
+
+    // 送信 → 応答 → 完了 の一連を実行
+    await act(async () => {
+      await store?.sendPrompt("/Users/john/projects/alpha", {
+        prompt: "永続化されるプロンプト",
+        permissionMode: "plan",
+        model: null,
+      });
+    });
+    emit({
+      run_id: "run-1",
+      kind: "message",
+      payload: {
+        type: "assistant",
+        session_id: "sess-persist-1234",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "復元されるべき応答" }],
+        },
+      },
+    });
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+
+    // アプリ再起動を模して Provider を破棄 → 新規マウント
+    first.unmount();
+    store = null;
+    mountProvider();
+
+    // 実行履歴が復元される
+    const runs = getStore().runs;
+    expect(runs).toHaveLength(1);
+    expect(runs[0].prompt).toBe("永続化されるプロンプト");
+    expect(runs[0].status).toBe("completed");
+
+    // 会話ログとセッション紐付けが復元される
+    const conversation = getStore().conversations.get(
+      "/Users/john/projects/alpha",
+    );
+    expect(conversation?.sessionId).toBe("sess-persist-1234");
+    expect(
+      conversation?.entries.some(
+        (e) => e.kind === "prompt" && e.text === "永続化されるプロンプト",
+      ),
+    ).toBe(true);
+
+    // 復元されたセッションで続きから再開できる（--resume に載る）
+    await act(async () => {
+      await getStore().sendPrompt("/Users/john/projects/alpha", {
+        prompt: "続きの指示",
+        permissionMode: "plan",
+        model: null,
+      });
+    });
+    expect(mockApi.startPromptRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({ resumeSessionId: "sess-persist-1234" }),
+    );
+  });
+
+  it("終了時に実行中だった run は「停止」として復元され中断が明示される", async () => {
+    const first = mountProvider();
+
+    await act(async () => {
+      await store?.sendPrompt("/Users/john/projects/alpha", {
+        prompt: "実行中のまま終了する",
+        permissionMode: "plan",
+        model: null,
+      });
+    });
+    // exit イベントを流さないまま（実行中のまま）再起動
+    first.unmount();
+    store = null;
+    mountProvider();
+
+    const runs = getStore().runs;
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("stopped");
+
+    const conversation = getStore().conversations.get(
+      "/Users/john/projects/alpha",
+    );
+    expect(conversation?.isRunning).toBe(false);
+    expect(
+      conversation?.entries.some(
+        (e) =>
+          e.kind === "error" &&
+          e.text.includes("アプリ終了により実行が中断されました"),
+      ),
+    ).toBe(true);
+  });
+
+  it("壊れた保存データは無視して空から始める", () => {
+    localStorage.setItem("ccm-prompt-runs-v1", "{broken json!!");
+    mountProvider();
+    expect(getStore().runs).toHaveLength(0);
+    expect(getStore().conversations.size).toBe(0);
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,11 @@
 // Setup file for Vitest
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
+
+// PromptRunsContext は localStorage に状態を永続化するため、
+// テスト間で状態が漏れないよう毎回クリアする
+beforeEach(() => {
+  localStorage.clear();
+});
 
 // Mock navigator.clipboard globally with more aggressive approach
 const mockClipboard = {

--- a/src/styles/prompt-runs.css
+++ b/src/styles/prompt-runs.css
@@ -501,3 +501,109 @@
 .project-latest-prompt--session {
   color: var(--color-secondary-600);
 }
+
+/* ---- Dashboard: カードのクイック実行コンポーザー ---- */
+
+.project-latest-prompt--none {
+  background: var(--color-secondary-100);
+  color: var(--color-secondary-500);
+}
+
+.project-latest-prompt--none .project-latest-prompt__label {
+  color: var(--color-secondary-500);
+  font-weight: 600;
+}
+
+.quick-prompt__toggle {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 5px 10px;
+  background: none;
+  border: 1px dashed var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-primary-600);
+  font-size: 0.8rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.quick-prompt__toggle:hover {
+  background: var(--color-primary-50);
+  border-color: var(--color-primary-300);
+}
+
+.quick-prompt {
+  margin-top: 6px;
+  padding: 8px;
+  background: var(--color-secondary-100);
+  border-radius: var(--radius-sm);
+}
+
+.quick-prompt__textarea {
+  width: 100%;
+  padding: 6px 8px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-family: inherit;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.quick-prompt__textarea:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+}
+
+.quick-prompt__controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.quick-prompt__controls select {
+  padding: 3px 6px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-size: 0.75rem;
+}
+
+.quick-prompt__button {
+  margin-left: auto;
+  padding: 3px 10px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.quick-prompt__button + .quick-prompt__button {
+  margin-left: 0;
+}
+
+.quick-prompt__button--primary {
+  background: var(--color-primary-600);
+  border-color: var(--color-primary-600);
+  color: #fff;
+}
+
+.quick-prompt__button--primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.quick-prompt__error {
+  margin-top: 6px;
+  color: var(--color-error-700);
+  font-size: 0.75rem;
+}

--- a/src/styles/prompt-runs.css
+++ b/src/styles/prompt-runs.css
@@ -248,23 +248,131 @@
   background: var(--color-primary-700);
 }
 
-/* ---- Dashboard: 実行中セクション ---- */
+/* ---- Dashboard: プロンプト実行状況セクション ---- */
 
-.dashboard-running-section {
+.dashboard-prompt-status {
   margin-bottom: var(--spacing-6);
 }
 
-.dashboard-running-section .prompt-runs-row {
+.dashboard-prompt-status .prompt-runs-row {
   box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.06));
 }
 
-.dashboard-running-section__list {
+.dashboard-prompt-status__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing-3);
+  margin-bottom: var(--spacing-3);
+}
+
+.dashboard-prompt-status__counts {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+}
+
+.dashboard-prompt-status__count {
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--color-secondary-100);
+  color: var(--color-secondary-700);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.dashboard-prompt-status__count--running {
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
+.dashboard-prompt-status__count--completed {
+  background: var(--color-success-100);
+  color: var(--color-success-700);
+}
+
+.dashboard-prompt-status__count--failed {
+  background: var(--color-error-100);
+  color: var(--color-error-700);
+}
+
+.dashboard-prompt-status__count--stopped {
+  background: var(--color-warning-100);
+  color: var(--color-warning-700);
+}
+
+.dashboard-prompt-status__all {
+  margin-left: auto;
+  padding: 4px 12px;
+  background: none;
+  border: none;
+  color: var(--color-primary-600);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard-prompt-status__all:hover {
+  text-decoration: underline;
+}
+
+.dashboard-prompt-status__list {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-3);
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+.dashboard-prompt-status__more {
+  margin-top: var(--spacing-2);
+  padding: 6px 12px;
+  width: 100%;
+  background: none;
+  border: 1px dashed var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-primary-600);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.dashboard-prompt-status__more:hover {
+  background: var(--color-secondary-100);
+}
+
+/* ---- Dashboard: プロジェクトカードの直近アクティビティ行 ---- */
+
+.project-latest-prompt {
+  margin-top: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--color-secondary-100);
+  color: var(--color-gray-800);
+  font-size: 0.82rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-latest-prompt--running {
+  background: var(--color-primary-100);
+}
+
+.project-latest-prompt--completed {
+  background: var(--color-success-100);
+}
+
+.project-latest-prompt--failed {
+  background: var(--color-error-100);
+}
+
+.project-latest-prompt--stopped {
+  background: var(--color-warning-100);
+}
+
+.project-latest-prompt--session {
+  color: var(--color-secondary-600);
 }
 
 /* ---- Dashboard: プロジェクトカードの状態バッジ ---- */

--- a/src/styles/prompt-runs.css
+++ b/src/styles/prompt-runs.css
@@ -128,49 +128,125 @@
   list-style: none;
 }
 
-/* ---- 実行 1 件の行（Prompts タブ / Dashboard 共用） ---- */
+/* ---- 状態インジケータ（色ドット / ピル） ----
+ * 状態は「色＋形（ドット）＋文字ラベル」の 3 要素で冗長に符号化する
+ * （WCAG 1.4.1 / IBM Carbon 状態インジケータ指針）。
+ * 絵文字は環境依存の見た目と走査ノイズのため使わない。
+ * 色は Carbon の注意階層に従う: 実行中=青 / 完了=緑 / 失敗=赤 / 停止=グレー系 */
+
+.run-status-dot {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-gray-400);
+  vertical-align: middle;
+}
+
+.run-status-dot--running {
+  background: var(--color-primary-500);
+  animation: prompt-runs-pulse 1.2s ease-in-out infinite;
+}
+
+.run-status-dot--completed {
+  background: var(--color-success-500);
+}
+
+.run-status-dot--failed {
+  background: var(--color-error-500);
+}
+
+.run-status-dot--stopped {
+  background: var(--color-warning-500);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .run-status-dot--running {
+    animation: none;
+  }
+}
+
+/* 行の左端に縦に揃える固定幅の状態ピル（F 字型走査の起点） */
+.run-status-pill {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+  width: 76px;
+  padding: 3px 0;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.run-status-pill__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.run-status-pill--running {
+  background: var(--color-primary-100);
+  color: var(--color-primary-700);
+}
+
+.run-status-pill--running .run-status-pill__dot {
+  background: var(--color-primary-500);
+  animation: prompt-runs-pulse 1.2s ease-in-out infinite;
+}
+
+.run-status-pill--completed {
+  background: var(--color-success-100);
+  color: var(--color-success-700);
+}
+
+.run-status-pill--completed .run-status-pill__dot {
+  background: var(--color-success-500);
+}
+
+.run-status-pill--failed {
+  background: var(--color-error-100);
+  color: var(--color-error-700);
+}
+
+.run-status-pill--failed .run-status-pill__dot {
+  background: var(--color-error-500);
+}
+
+.run-status-pill--stopped {
+  background: var(--color-warning-100);
+  color: var(--color-warning-700);
+}
+
+.run-status-pill--stopped .run-status-pill__dot {
+  background: var(--color-warning-500);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .run-status-pill--running .run-status-pill__dot {
+    animation: none;
+  }
+}
+
+/* ---- 実行 1 件の行（Prompts タブ / Dashboard 共用） ----
+ * 主役はプロンプト本文。メタ情報は 2 行目に淡色で降格し、
+ * 1 行あたりの要素数を抑える（機能的ミニマリズム）。 */
 
 .prompt-runs-row {
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-3);
-  padding: var(--spacing-4);
+  padding: var(--spacing-3) var(--spacing-4);
   background: #fff;
   border: 1px solid var(--color-gray-200);
-  border-left: 4px solid var(--color-gray-300);
   border-radius: var(--radius-md);
 }
 
-.prompt-runs-row--running {
-  border-left-color: var(--color-primary-500);
-}
-
-.prompt-runs-row--completed {
-  border-left-color: var(--color-success-500);
-}
-
+/* 高注意（失敗）だけ左枠でも強調する（Carbon の注意階層） */
 .prompt-runs-row--failed {
-  border-left-color: var(--color-error-500);
-}
-
-.prompt-runs-row--stopped {
-  border-left-color: var(--color-warning-500);
-}
-
-.prompt-runs-row__icon {
-  flex-shrink: 0;
-  font-size: 1.1rem;
-  line-height: 1.5;
-}
-
-.prompt-runs-row__icon--running {
-  animation: prompt-runs-pulse 1.2s ease-in-out infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .prompt-runs-row__icon--running {
-    animation: none;
-  }
+  border-left: 3px solid var(--color-error-500);
 }
 
 .prompt-runs-row__body {
@@ -178,37 +254,57 @@
   min-width: 0;
 }
 
-.prompt-runs-row__title {
+.prompt-runs-row__primary {
   display: flex;
-  flex-wrap: wrap;
   align-items: baseline;
-  gap: var(--spacing-2);
+  gap: var(--spacing-3);
 }
 
-.prompt-runs-row__project {
-  color: var(--color-gray-800);
-  font-weight: 700;
-}
-
-.prompt-runs-row__meta {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-2);
-  color: var(--color-secondary-500);
-  font-size: var(--font-size-xs);
-}
-
+/* 可読行長の研究（50〜75 字）に基づき本文の伸長を抑える */
 .prompt-runs-row__prompt {
-  margin-top: 2px;
+  flex: 1;
+  max-width: 60ch;
   overflow: hidden;
   color: var(--color-gray-800);
   font-size: var(--font-size-sm);
+  font-weight: 600;
+  line-height: 1.55;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.prompt-runs-row__when {
+  flex-shrink: 0;
+  margin-left: auto;
+  color: var(--color-secondary-400);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runs-row__secondary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  margin-top: 2px;
+  color: var(--color-secondary-500);
+  font-size: var(--font-size-xs);
+}
+
+.prompt-runs-row__project {
+  font-weight: 600;
+  color: var(--color-secondary-600);
+}
+
+.prompt-runs-row__danger-mode {
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--color-error-100);
+  color: var(--color-error-700);
+  font-weight: 700;
+}
+
 .prompt-runs-row__activity {
   margin-top: 4px;
+  max-width: 60ch;
   overflow: hidden;
   color: var(--color-secondary-500);
   font-family: var(--font-family-mono, monospace);
@@ -220,16 +316,17 @@
 .prompt-runs-row__actions {
   display: flex;
   flex-shrink: 0;
+  align-self: center;
   gap: var(--spacing-2);
 }
 
 .prompt-runs-row__button {
-  padding: 5px 14px;
+  padding: 4px 12px;
   background: #fff;
   border: 1px solid var(--color-gray-300);
   border-radius: 6px;
   color: var(--color-gray-800);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-weight: 600;
   cursor: pointer;
 }
@@ -344,12 +441,26 @@
 /* ---- Dashboard: プロジェクトカードの直近アクティビティ行 ---- */
 
 .project-latest-prompt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   margin-top: 6px;
   padding: 4px 10px;
   border-radius: var(--radius-sm);
   background: var(--color-secondary-100);
   color: var(--color-gray-800);
   font-size: 0.82rem;
+}
+
+.project-latest-prompt__label {
+  flex-shrink: 0;
+  font-weight: 700;
+  font-size: 0.72rem;
+}
+
+.project-latest-prompt__text {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -359,50 +470,34 @@
   background: var(--color-primary-100);
 }
 
+.project-latest-prompt--running .project-latest-prompt__label {
+  color: var(--color-primary-700);
+}
+
 .project-latest-prompt--completed {
   background: var(--color-success-100);
+}
+
+.project-latest-prompt--completed .project-latest-prompt__label {
+  color: var(--color-success-700);
 }
 
 .project-latest-prompt--failed {
   background: var(--color-error-100);
 }
 
+.project-latest-prompt--failed .project-latest-prompt__label {
+  color: var(--color-error-700);
+}
+
 .project-latest-prompt--stopped {
   background: var(--color-warning-100);
 }
 
+.project-latest-prompt--stopped .project-latest-prompt__label {
+  color: var(--color-warning-700);
+}
+
 .project-latest-prompt--session {
   color: var(--color-secondary-600);
-}
-
-/* ---- Dashboard: プロジェクトカードの状態バッジ ---- */
-
-.project-run-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 10px;
-  border-radius: 999px;
-  font-size: 0.72rem;
-  font-weight: 700;
-}
-
-.project-run-badge--running {
-  background: var(--color-primary-100);
-  color: var(--color-primary-700);
-}
-
-.project-run-badge--completed {
-  background: var(--color-success-100);
-  color: var(--color-success-700);
-}
-
-.project-run-badge--failed {
-  background: var(--color-error-100);
-  color: var(--color-error-700);
-}
-
-.project-run-badge--stopped {
-  background: var(--color-warning-100);
-  color: var(--color-warning-700);
 }

--- a/src/styles/prompt-runs.css
+++ b/src/styles/prompt-runs.css
@@ -607,3 +607,30 @@
   color: var(--color-error-700);
   font-size: 0.75rem;
 }
+
+/* ---- Dashboard: カードの実行中プログレス ---- */
+
+.project-run-progress {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 0 10px;
+}
+
+.project-run-progress__activity {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-secondary-500);
+  font-family: var(--font-family-mono, monospace);
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-run-progress__elapsed {
+  flex-shrink: 0;
+  color: var(--color-secondary-400);
+  font-size: 0.72rem;
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,4 +1,4 @@
-import { expect, afterEach, vi } from "vitest";
+import { expect, afterEach, beforeEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import "@testing-library/jest-dom";
@@ -9,6 +9,12 @@ expect.extend(matchers);
 // runs a cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {
   cleanup();
+});
+
+// PromptRunsContext は localStorage に状態を永続化するため、
+// テスト間で状態が漏れないよう毎回クリアする
+beforeEach(() => {
+  localStorage.clear();
 });
 
 // Global setup for test environment

--- a/src/tests/Dashboard.test.tsx
+++ b/src/tests/Dashboard.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../api", () => ({
   api: {
     getSessionStats: vi.fn(),
     getProjectSummary: vi.fn(),
+    getAllSessions: vi.fn(),
   },
 }));
 
@@ -16,6 +17,8 @@ const mockApi = api.api as any;
 describe("Dashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Dashboard はカードの最新セッション表示のため getAllSessions も呼ぶ
+    mockApi.getAllSessions.mockResolvedValue([]);
   });
 
   it("renders loading state initially", () => {


### PR DESCRIPTION
## 概要

Dashboard を「プロジェクト全体の状況ボード」にし、プロンプトとその対応状況をプロジェクト横断で一覧できるようにします。

## 変更内容

### 1. プロンプト実行状況セクション（Dashboard 上部）

従来の「実行中のプロンプト」は実行中のみ表示で、終わると消えていました。これを拡張し:

- **完了・失敗・停止も含めた直近の実行を常設表示**（実行中を先頭に新しい順・最大6件）
- 状態別の件数チップ（⏳実行中 / ✅完了 / ❌失敗 / ⏹停止）
- 実行中の行は経過時間と実行中ツールをライブ表示、その場で停止可能
- 「すべて見る →」と超過分リンクから Prompts タブへ遷移
- 行コンポーネントは Prompts タブと共通化（`PromptRunRow` として抽出）

### 2. プロジェクトカードの直近アクティビティ行

各カードのパスの下に1行追加:

- アプリ内で実行したプロンプトがあれば **`{状態アイコン} {プロンプト本文}`**（状態色の背景）
- 無ければ **~/.claude の最新セッションのプレビュー**を表示。アプリ外（ターミナル等）で実行した claude の作業も見える

後者は issue #22（Recent Projects の各 project にも最新のメッセージを表示したい）の内容です。

## 動作確認

- `npx tsc --noEmit` / `npx vitest run` — **98 件通過**（新規 5 件: セクション表示・件数チップ・「すべて見る」遷移・カードのプロンプト表示・セッションプレビュー fallback）
- ブラウザ（モック）: 2プロジェクトで実行し、実行中＋完了の混在表示・カードの状態行・「すべて見る」遷移を目視確認

## 追記: 可読性研究に基づく表示の再設計

「人間が読みやすい表示」の研究を調べ、その知見で実行状況の表示（Dashboard セクション / Prompts タブ / プロジェクトカード）を再設計しました。

| 適用した知見 | 出典 | 実装 |
|---|---|---|
| F 字型走査: 左端を縦にスキャンし各行の最初の 1〜2 語しか読まない | [NN/g Text Scanning Patterns](https://www.nngroup.com/articles/text-scanning-patterns-eyetracking/), [F-Shaped Pattern](https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/), [First 2 Words](https://www.nngroup.com/articles/first-2-words-a-signal-for-scanning/) | 行頭に固定幅の状態ピルを縦に揃え、走査の起点にする |
| 状態は色・形・ラベルの 3 要素以上で冗長符号化（色覚多様性 / WCAG 1.4.1）。ラベルが最重要 | [IBM Carbon Status Indicator](https://carbondesignsystem.com/patterns/status-indicator-pattern/), [WCAG 1.4.1](https://accessibility.build/wcag/1-4-1) | 絵文字（⏳✅❌⏹）を全廃し「色ドット＋文字ラベル」に統一。grayscale でも判別可能 |
| 注意階層: 高注意（失敗）だけ強調し、完了は静かに。色は 実行中=青 / 完了=緑 / 失敗=赤 | IBM Carbon 同上 | 失敗行のみ赤の左枠。完了行は枠色なし |
| 相対時刻の短縮表記が最速で読める。正確な時刻は補助で | [Activity Feed Design](https://getstream.io/blog/activity-feed-design/), [Timeline Pattern](https://uxpatterns.dev/patterns/data-display/timeline) | 右端に「たった今 / 3分前」、title 属性に絶対時刻 |
| 可読行長は 50〜75 字 | [UXPin Optimal Line Length](https://www.uxpin.com/studio/blog/optimal-line-length-for-readability/) | プロンプト本文・活動行を max-width 60ch で省略 |
| 機能的ミニマリズム: 理解に寄与しない要素は削る。指標は 5〜6 個まで | [Smashing Dashboard Design](https://www.smashingmagazine.com/2021/11/dashboard-design-research-decluttering-data-viz/), Carbon | `plan` 表記削除（既定値のため情報ゼロ。bypassPermissions のみ「全許可」警告）、カードの状態バッジと本文行を統合、メタ情報を 2 行目に淡色で降格 |

### Before / After（行の構造）

```
Before:  ⏳ mobile-app 1s plan            ← 状態が絵文字のみ・メタが主役
         READMEを更新して                  ← 全幅に伸びる

After:   [● 実行中]  READMEを更新して…(60ch)         1s 経過
         mobile-app · 2s · 3 turns · $0.01     [停止][開く]
         ⚙ Read package.json
```

close #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

