### PR TITLE
プロジェクト詳細画面の UX 改善（フェーズ1）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -943,10 +943,9 @@ body {
 
 .project-path {
   font-size: 0.8rem;
-  color: #7f8c8d;
+  color: #495057;
   margin: 0;
   word-break: break-all;
-  opacity: 0.7;
 }
 
 .project-stats {
@@ -1271,34 +1270,33 @@ body {
 
 .message-search-input {
   padding: 0.5rem;
-  border: 1px solid #555;
+  border: 1px solid #ced4da;
   border-radius: 4px;
   font-size: 0.9rem;
   min-width: 200px;
-  background: #2d2d2d;
-  color: #f0f0f0;
+  background: #ffffff;
+  color: #212529;
   transition: border-color 0.2s, background-color 0.2s;
 }
 
 .message-search-input:focus {
   outline: none;
   border-color: #3b82f6;
-  background: #333333;
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
 .message-search-input::placeholder {
-  color: #9ca3af;
+  color: #6c757d;
   opacity: 1;
 }
 
 .message-type-select {
   padding: 0.5rem;
-  border: 1px solid #555;
+  border: 1px solid #ced4da;
   border-radius: 4px;
   font-size: 0.9rem;
-  background: #2d2d2d;
-  color: #f0f0f0;
+  background: #ffffff;
+  color: #212529;
   min-width: 120px;
   transition: border-color 0.2s, background-color 0.2s;
 }
@@ -1306,7 +1304,6 @@ body {
 .message-type-select:focus {
   outline: none;
   border-color: #3b82f6;
-  background: #333333;
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
@@ -2328,11 +2325,9 @@ button:hover:not(:disabled) {
 }
 
 .project-last-activity {
-  color: #6c757d;
+  color: #495057;
   font-size: 0.75rem;
-  font-style: italic;
   margin: 0;
-  opacity: 0.8;
 }
 
 /* Project Stats Horizontal Layout */
@@ -2652,13 +2647,8 @@ button:hover:not(:disabled) {
 }
 
 .meta-label {
-  color: var(--text-tertiary);
+  color: #495057;
   font-size: 0.75rem;
-  border-bottom: 1px solid #e9ecef;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  background: white;
-  position: relative;
 }
 
 .session-card:hover {
@@ -3699,13 +3689,23 @@ button:hover:not(:disabled) {
 /* .claude Directory Styles */
 .project-directory-content {
   display: flex;
-  gap: 2rem;
-  height: calc(100vh - 300px);
+  gap: 1.5rem;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 1.5rem 0;
+  background: #f5f7fa;
 }
 
 .claude-directory-files {
   flex: 1;
   min-width: 300px;
+  min-height: 0;
+  overflow-y: auto;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 1rem 1.5rem;
 }
 
 .claude-directory-files h3 {
@@ -3783,6 +3783,7 @@ button:hover:not(:disabled) {
 /* File Viewer/Editor */
 .claude-file-viewer {
   flex: 2;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   background: var(--bg-primary);
@@ -4193,3 +4194,121 @@ button:hover:not(:disabled) {
   }
 }
 
+
+
+/* ============================================================
+ * Project 詳細画面の UX 改善（issue #46）
+ * 既存の .session-card / .project-tabs 系は複数箇所に定義があるため、
+ * 後勝ちになるようここに集約して上書きする。
+ * 方針は Dashboard / Prompts と同じ可読性研究ベース:
+ * 内容で識別・メタ情報の降格・偽アフォーダンスの排除。
+ * ============================================================ */
+
+/* ヘッダーの統計 1 行メタ（旧 stat-card 3 枚の置き換え） */
+.project-meta-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #495057;
+  font-size: 0.85rem;
+}
+
+.project-meta-line__todos {
+  color: #b45309;
+  font-weight: 600;
+}
+
+/* タブ: 1 行のシンプルなテキストタブ */
+.project-tabs .tab-button {
+  padding: 0.65rem 1rem;
+  font-size: 0.95rem;
+}
+
+/* セッションカード: プレビュー本文が主役、メタは 1 行に降格 */
+.session-card {
+  padding: 0.75rem 1rem;
+}
+
+.session-card-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.session-preview-title {
+  flex: 1;
+  margin: 0;
+  color: #212529;
+  font-size: 0.88rem;
+  font-weight: 600;
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.session-card .session-status-badge.status-processing {
+  flex-shrink: 0;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.session-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-top: 4px;
+  color: #495057;
+  font-size: 0.75rem;
+}
+
+.session-card-meta__branch {
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-card-meta__id {
+  margin-left: auto;
+  color: #868e96;
+  font-family: "SF Mono", Monaco, Consolas, monospace;
+  font-size: 0.7rem;
+}
+
+/* 空状態: 行き止まりにせず Prompt タブへの導線を置く */
+.no-sessions {
+  padding: 2rem 1rem;
+  color: #495057;
+  text-align: center;
+}
+
+.no-sessions__cta {
+  margin-top: 0.75rem;
+  padding: 6px 14px;
+  background: none;
+  border: 1px dashed #adb5bd;
+  border-radius: 6px;
+  color: #0284c7;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.no-sessions__cta:hover {
+  background: #f0f9ff;
+  border-color: #7dd3fc;
+}
+
+/* キーボードフォーカスの可視化（session-card / file-item） */
+.session-card:focus-visible,
+.file-item:focus-visible {
+  outline: 2px solid #0ea5e9;
+  outline-offset: -2px;
+}

--- a/src/components/ProjectScreen.tsx
+++ b/src/components/ProjectScreen.tsx
@@ -31,6 +31,9 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
   promptTabRequest,
 }) => {
   const [sessions, setSessions] = useState<ClaudeSession[]>([]);
+  // loadProjectData（再読込・プロジェクト切替）から最新の選択状態を
+  // stale closure なしで参照するための ref
+  const selectedSessionRef = useRef<ClaudeSession | null>(null);
   const [selectedSession, setSelectedSession] = useState<ClaudeSession | null>(
     null,
   );
@@ -260,6 +263,22 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
         (p) => p.project_path === projectPath,
       );
       setProjectSummary(summary || null);
+
+      // 未選択（またはプロジェクト切替で旧選択が無効）なら最新セッションを
+      // 自動で開く。利用の大半は「最新のやり取りを見る」なので 1 クリック省く。
+      // 再読込時に有効な選択があれば維持する（refreshProjectData が再選択する）
+      const current = selectedSessionRef.current;
+      const currentIsValid =
+        current !== null &&
+        projectSessions.some((s) => s.session_id === current.session_id);
+      if (!currentIsValid && projectSessions.length > 0) {
+        const latest = [...projectSessions].sort(
+          (a, b) =>
+            new Date(b.file_modified_time).getTime() -
+            new Date(a.file_modified_time).getTime(),
+        )[0];
+        void loadSessionMessages(latest);
+      }
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to load project data",
@@ -504,6 +523,7 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
     try {
       setLoadingMessages(true);
       setSelectedSession(session);
+      selectedSessionRef.current = session;
       const data = await api.getSessionMessages(session.session_id);
       setMessages(data);
       setFilteredMessages(data);
@@ -783,66 +803,44 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
               </div>
             )}
           </div>
+          {/*
+            統計は 1 行のインラインメタに圧縮する。
+            旧: カード 3 枚（約 100px + hover 演出のみでクリック不可の
+            偽アフォーダンス）。ヘッダーを薄くしてコンテンツ領域を広げる。
+          */}
           {projectSummary && (
-            <div className="project-stats-horizontal">
-              <div className="stat-card stat-card--sessions">
-                <div className="stat-icon">💬</div>
-                <div className="stat-content">
-                  <div className="stat-value">
-                    {projectSummary.session_count}
-                  </div>
-                  <div className="stat-label">Sessions</div>
-                </div>
-              </div>
-              <div className="stat-card stat-card--messages">
-                <div className="stat-icon">📝</div>
-                <div className="stat-content">
-                  <div className="stat-value">
-                    {projectSummary.total_messages}
-                  </div>
-                  <div className="stat-label">Messages</div>
-                </div>
-              </div>
-              <div
-                className={`stat-card stat-card--todos ${projectSummary.active_todos > 0 ? "stat-card--warning" : ""}`}
-              >
-                <div className="stat-icon">
-                  {projectSummary.active_todos > 0 ? "⚠️" : "✅"}
-                </div>
-                <div className="stat-content">
-                  <div className="stat-value">
-                    {projectSummary.active_todos}
-                  </div>
-                  <div className="stat-label">TODOs</div>
-                </div>
-              </div>
+            <div className="project-meta-line">
+              <span>{projectSummary.session_count} sessions</span>
+              <span aria-hidden="true">·</span>
+              <span>{projectSummary.total_messages} messages</span>
+              {projectSummary.active_todos > 0 && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span className="project-meta-line__todos">
+                    {projectSummary.active_todos} TODO
+                  </span>
+                </>
+              )}
             </div>
           )}
         </div>
       </div>
 
+      {/* タブは 1 行に。サブタイトル（ヘッダー統計と食い違う件数表示）は出さない */}
       <div className="project-tabs">
         <button
           className={`tab-button ${activeTab === "sessions" ? "active" : ""}`}
           onClick={() => setActiveTab("sessions")}
           aria-label={`View sessions (${sessions.length} sessions)`}
         >
-          <div className="tab-icon">💬</div>
-          <div className="tab-content">
-            <div className="tab-title">Sessions</div>
-            <div className="tab-subtitle">{sessions.length} conversations</div>
-          </div>
+          Sessions
         </button>
         <button
           className={`tab-button ${activeTab === "directory" ? "active" : ""}`}
           onClick={() => setActiveTab("directory")}
           aria-label="View .claude directory files"
         >
-          <div className="tab-icon">📁</div>
-          <div className="tab-content">
-            <div className="tab-title">.claude Directory</div>
-            <div className="tab-subtitle">Project configuration</div>
-          </div>
+          .claude Directory
         </button>
         <button
           className={`tab-button ${activeTab === "prompt" ? "active" : ""}`}
@@ -852,11 +850,7 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
           }}
           aria-label="Run a prompt against this project"
         >
-          <div className="tab-icon">✨</div>
-          <div className="tab-content">
-            <div className="tab-title">Prompt</div>
-            <div className="tab-subtitle">Claude に指示を出す</div>
-          </div>
+          Prompt
         </button>
       </div>
 
@@ -865,7 +859,17 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
           <div className="project-sessions-list">
             {sessions.length === 0 ? (
               <div className="no-sessions">
-                No sessions found for this project
+                <p>このプロジェクトにはまだセッションがありません。</p>
+                <button
+                  type="button"
+                  className="no-sessions__cta"
+                  onClick={() => {
+                    setPromptTabVisited(true);
+                    setActiveTab("prompt");
+                  }}
+                >
+                  Prompt タブで Claude に指示を出す →
+                </button>
               </div>
             ) : (
               sessions
@@ -875,73 +879,65 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
                     new Date(a.file_modified_time).getTime(),
                 )
                 .map((session) => (
+                  /*
+                    カードの主見出しは会話内容のプレビュー（人は ID では
+                    セッションを思い出せない — 記憶より認識）。ID は
+                    メタ行の末尾に等幅で置く。バッジは処理中のみ表示
+                    （正常状態にバッジは不要）。
+                  */
                   <div
                     key={session.session_id}
                     className={`session-card ${selectedSession?.session_id === session.session_id ? "selected" : ""}`}
                     onClick={() => loadSessionMessages(session)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        loadSessionMessages(session);
+                      }
+                    }}
                     role="button"
                     tabIndex={0}
                     aria-label={`Open session ${session.session_id.substring(0, 8)} with ${session.message_count} messages`}
                   >
-                    <div className="session-card-header">
-                      <div className="session-id-section">
-                        <h4 className="session-title">
-                          Session {session.session_id.substring(0, 8)}...
-                        </h4>
+                    <div className="session-card-title-row">
+                      <h4 className="session-preview-title">
+                        {session.latest_content_preview ??
+                          `Session ${session.session_id.substring(0, 8)}`}
+                      </h4>
+                      {session.is_processing && (
                         <span
-                          className={`session-status-badge ${session.is_processing ? "status-processing" : "status-completed"}`}
-                          title={
-                            session.is_processing
-                              ? "Session has sequences still processing"
-                              : "Session completed"
-                          }
-                          aria-label={
-                            session.is_processing ? "Processing" : "Completed"
-                          }
+                          className="session-status-badge status-processing"
+                          aria-label="Processing"
                         >
-                          <span className="status-icon">
-                            {session.is_processing ? "⏳" : "✅"}
-                          </span>
-                          {session.is_processing ? "Processing" : "Complete"}
+                          処理中
                         </span>
-                      </div>
+                      )}
                     </div>
-                    {session.latest_content_preview && (
-                      <div className="session-preview">
-                        <p className="preview-text">
-                          {session.latest_content_preview}
-                        </p>
-                      </div>
-                    )}
                     <div className="session-card-meta">
-                      <div className="meta-item">
-                        <span className="meta-icon">💬</span>
-                        <span className="meta-value">
-                          {session.message_count}
-                        </span>
-                        <span className="meta-label">messages</span>
-                      </div>
+                      <span
+                        title={formatDateTooltip(session.file_modified_time)}
+                      >
+                        {formatDateTime(session.file_modified_time, {
+                          style: "compact",
+                          showRelative: true,
+                        })}
+                      </span>
+                      <span aria-hidden="true">·</span>
+                      <span>{session.message_count} msg</span>
                       {session.git_branch && (
-                        <div className="meta-item">
-                          <span className="meta-icon">🌿</span>
-                          <span className="meta-value">
+                        <>
+                          <span aria-hidden="true">·</span>
+                          <span
+                            className="session-card-meta__branch"
+                            title={session.git_branch}
+                          >
                             {session.git_branch}
                           </span>
-                          <span className="meta-label">branch</span>
-                        </div>
+                        </>
                       )}
-                      <div className="meta-item">
-                        <span
-                          className="meta-value"
-                          title={formatDateTooltip(session.file_modified_time)}
-                        >
-                          {formatDateTime(session.file_modified_time, {
-                            style: "compact",
-                            showRelative: true,
-                          })}
-                        </span>
-                        <span className="meta-label">updated</span>
-                      </div>
+                      <span className="session-card-meta__id">
+                        {session.session_id.substring(0, 8)}
+                      </span>
                     </div>
                   </div>
                 ))
@@ -1110,6 +1106,14 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
                       key={file.path}
                       className={`file-item ${selectedFile?.path === file.path ? "selected" : ""}`}
                       onClick={() => loadFileContent(file)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          loadFileContent(file);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
                     >
                       <div className="file-info">
                         <span className="file-name">{file.name}</span>

--- a/src/components/__tests__/ProjectScreen.test.tsx
+++ b/src/components/__tests__/ProjectScreen.test.tsx
@@ -94,13 +94,10 @@ describe("ProjectScreen", () => {
     expect(
       screen.getByText("/Users/john.documents_test/project"),
     ).toBeInTheDocument();
-    // Check for the stat cards
-    expect(screen.getByText("3")).toBeInTheDocument();
-    expect(screen.getAllByText("Sessions")).toHaveLength(2); // One in stat card, one in tab
-    expect(screen.getByText("25")).toBeInTheDocument();
-    expect(screen.getByText("Messages")).toBeInTheDocument();
-    expect(screen.getByText("2")).toBeInTheDocument();
-    expect(screen.getByText("TODOs")).toBeInTheDocument();
+    // ヘッダー統計は 1 行のインラインメタ
+    expect(screen.getByText("3 sessions")).toBeInTheDocument();
+    expect(screen.getByText("25 messages")).toBeInTheDocument();
+    expect(screen.getByText("2 TODO")).toBeInTheDocument();
   });
 
   it("should display .claude directory information when tab is clicked", async () => {
@@ -132,25 +129,28 @@ describe("ProjectScreen", () => {
   it("should render sessions list", async () => {
     render(<ProjectScreen projectPath="-Users-john-documents-test-project" />);
 
+    // プレビュー本文がカードの主見出しになる
     await waitFor(() => {
-      expect(screen.getByText("2 conversations")).toBeInTheDocument();
+      expect(screen.getByText("Test preview content")).toBeInTheDocument();
     });
-
-    expect(screen.getAllByText(/Session session-.../)).toHaveLength(2);
-    expect(screen.getByText("Test preview content")).toBeInTheDocument();
     expect(screen.getByText("Another preview")).toBeInTheDocument();
+    // ID はメタ行の等幅サブテキストに降格（8 文字切り詰めで両カードとも "session-"）
+    expect(screen.getAllByText("session-")).toHaveLength(2);
   });
 
-  it("should load messages when session is selected", async () => {
+  it("should auto-select the latest session and load its messages", async () => {
     render(<ProjectScreen projectPath="-Users-john-documents-test-project" />);
 
+    // 最新セッション（file_modified_time が新しい方）が自動で開く
     await waitFor(() => {
-      expect(screen.getByText("2 conversations")).toBeInTheDocument();
+      expect(mockApi.getSessionMessages).toHaveBeenCalled();
     });
 
-    const sessionItems = screen.getAllByText(/Session session-.../);
-    const sessionItem = sessionItems[0];
-    fireEvent.click(sessionItem);
+    // カードをクリックすれば任意のセッションへ切り替えられる
+    await waitFor(() => {
+      expect(screen.getByText("Test preview content")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Test preview content"));
 
     await waitFor(() => {
       expect(mockApi.getSessionMessages).toHaveBeenCalledWith("session-123");


### PR DESCRIPTION
## 概要

issue #46「project 詳細を使いやすくして」対応の第1弾です。issue のラベル指定どおり **ux-design-specialist エージェントによる UX 評価**を先に行い、その指摘（深刻度 P0〜P2 の25項目）から効果の大きいものを実装しました。

## 実装内容

### 「壊れている」と受け取られる問題の修復（P0）
| 問題 | 修正 |
|---|---|
| メッセージ検索欄・フィルタが**ダーク UI の残骸**（#2d2d2d 背景）でライト画面に浮いていた | 白背景・ライトボーダーに |
| `.meta-label` に CSS マージ事故でカードのプロパティが混入し、ただのラベル語が**リンク風**に見えていた | 混入プロパティを除去 |
| Directory タブが `height: calc(100vh - 300px)`（二重定義の後勝ち）で**下部に巨大な死に領域** | flex ベースに修正、左ペインを Sessions と揃った白カードに |
| `.project-path` が opacity 薄化で実効コントラスト **2.9:1**（WCAG AA 未達） | opacity 廃止、#495057 で 4.5:1 以上に |

### セッションを内容で識別できるように（この画面の最大の問題）
- カード主見出しを「Session 8桁ID…」→ **会話プレビューの2行クランプ**に（人は ID でセッションを思い出せない — 記憶より認識の原則）
- ID はメタ行末尾の等幅サブテキストへ降格、メタは1行に圧縮（`相対時刻 · 15 msg · main`）
- 「Complete」バッジ廃止（**処理中のときだけ**表示。正常状態にバッジは不要）
- カード高 約120px → 約72px（一覧性 1.6倍）

### 迷い・手数の削減
- ヘッダー統計カード3枚（クリック不可なのに hover 演出つきの偽アフォーダンス）→ **1行のインラインメタ**。ヘッダーが約100px 薄くなりコンテンツが広がる
- タブ1行化。ヘッダーと**食い違う件数表示**（8 SESSIONS vs 1 conversations）を廃止
- **最新セッションを自動選択**（開くたびの1クリック削減。再読込時は選択維持）
- セッション0件の空状態に「Prompt タブで指示を出す →」導線

### アクセシビリティ（WCAG 2.1.1）
- セッションカード: `role="button"` だけあって Enter/Space が効かなかった → キーハンドラ実装
- `.file-item`: role / tabIndex / キーハンドラを追加、フォーカスリング可視化

## UX 評価からの残項目（今後の候補）

- **C**: 右ペインを MessagesList に統合（60ch 行長・CWD 重複除去・diff 表示の共通化）
- **D**: セッション横断検索・日付グルーピング
- **G**: ファイル編集の自動保存既定 OFF・未保存ガード
- I/J/K/L: アイコンボタンの改善・Prompt→Sessions 導線・ラベル日本語統一・CSS 重複整理

## 検証

- テスト 105 件通過（ProjectScreen テストは新 UI に合わせて更新）
- ブラウザで before/after を目視確認（ヘッダー圧縮・カード再設計・Directory タブの死に領域解消・自動選択）

close #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
