### PR TITLE
GitHub Issue をまとめて claude に対応させるキュー機能

### DIFF
--- a/src/components/ProjectScreen.tsx
+++ b/src/components/ProjectScreen.tsx
@@ -101,6 +101,8 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
   const [filteredMessages, setFilteredMessages] = useState<ClaudeMessage[]>([]);
   const [renderAsMarkdown, setRenderAsMarkdown] = useState(false);
   const messageListRef = useRef<HTMLDivElement>(null);
+  // プレビュー位置への自動スクロール用タイマー（アンマウント時にクリア）
+  const scrollToPreviewTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Toast notifications
@@ -178,6 +180,15 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
   useEffect(() => {
     loadProjectData();
   }, [projectPath]);
+
+  // アンマウント時に自動スクロールのタイマーを破棄する
+  useEffect(() => {
+    return () => {
+      if (scrollToPreviewTimeoutRef.current) {
+        clearTimeout(scrollToPreviewTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Dashboard / Prompts 一覧からの「Prompt タブで開く」リクエストに応える
   const promptTabRequestNonce = promptTabRequest?.nonce ?? 0;
@@ -587,7 +598,16 @@ export const ProjectScreen: React.FC<ProjectScreenProps> = ({
       setFilteredMessages(data);
 
       if (data.length > 0 && session.latest_content_preview) {
-        setTimeout(() => {
+        // タイマーは ref に保持し、アンマウント時にクリアする。
+        // 破棄後に発火すると document 参照で未処理例外になる
+        // （テスト環境の jsdom 破棄後の発火で CI が落ちた実レース）
+        if (scrollToPreviewTimeoutRef.current) {
+          clearTimeout(scrollToPreviewTimeoutRef.current);
+        }
+        scrollToPreviewTimeoutRef.current = setTimeout(() => {
+          scrollToPreviewTimeoutRef.current = null;
+          // アンマウント済みなら何もしない
+          if (!messageListRef.current) return;
           let targetMessage = null;
           let targetIndex = -1;
 

--- a/src/components/PromptRunner.tsx
+++ b/src/components/PromptRunner.tsx
@@ -362,9 +362,40 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [stopError, setStopError] = useState<string | null>(null);
 
+  // GitHub issue 対応キューの入力 UI
+  const [issueInputOpen, setIssueInputOpen] = useState(false);
+  const [issueNumbersText, setIssueNumbersText] = useState("");
+  const [issueMode, setIssueMode] =
+    useState<PermissionMode>("bypassPermissions");
+  const [issueConfirmOpen, setIssueConfirmOpen] = useState(false);
+
+  const parsedIssueNumbers = useMemo(
+    () =>
+      issueNumbersText
+        .split(/[,\s#]+/)
+        .map((token) => Number.parseInt(token, 10))
+        .filter((n) => Number.isInteger(n) && n > 0),
+    [issueNumbersText],
+  );
+
   // 会話ログ・実行状態はストアがプロジェクト単位で保持している
-  const { conversations, sendPrompt, resetConversation, stopRun } =
-    usePromptRuns();
+  const {
+    conversations,
+    issueQueues,
+    sendPrompt,
+    resetConversation,
+    stopRun,
+    startIssueRuns,
+    cancelIssueQueue,
+  } = usePromptRuns();
+  const issueQueue = issueQueues.get(projectPath) ?? null;
+
+  const handleStartIssueRuns = useCallback(() => {
+    if (parsedIssueNumbers.length === 0) return;
+    startIssueRuns(projectPath, parsedIssueNumbers, issueMode);
+    setIssueNumbersText("");
+    setIssueInputOpen(false);
+  }, [parsedIssueNumbers, startIssueRuns, projectPath, issueMode]);
   const conversation = conversations.get(projectPath) ?? EMPTY_CONVERSATION;
   const { entries, stderrLines, sessionId, isRunning, activeRunId } =
     conversation;
@@ -525,6 +556,94 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
         </div>
       )}
 
+      {/* GitHub issue 対応キュー（issue #12）。
+          issue の取得は認証済みの gh CLI に任せるためトークンは不要。
+          同一ワーキングツリーでの競合を避けるため 1 件ずつ順次対応する */}
+      {issueQueue ? (
+        <div className="issue-runner issue-runner--active">
+          <span
+            className="run-status-dot run-status-dot--running"
+            aria-hidden="true"
+          />
+          <span className="issue-runner__status">
+            Issue 対応中:{" "}
+            {issueQueue.active !== null ? `#${issueQueue.active}` : "待機中"}
+            {issueQueue.pending.length > 0 &&
+              `（残り ${issueQueue.pending.length} 件: ${issueQueue.pending
+                .map((n) => `#${n}`)
+                .join(", ")}）`}
+          </span>
+          {issueQueue.pending.length > 0 && (
+            <button
+              type="button"
+              className="prompt-runner__link-button"
+              onClick={() => cancelIssueQueue(projectPath)}
+            >
+              残りをキャンセル
+            </button>
+          )}
+        </div>
+      ) : issueInputOpen ? (
+        <div className="issue-runner issue-runner--form">
+          <div className="issue-runner__controls">
+            <input
+              type="text"
+              className="issue-runner__input"
+              value={issueNumbersText}
+              onChange={(e) => setIssueNumbersText(e.target.value)}
+              placeholder="対応する issue 番号（例: 12, 34）"
+              aria-label="Issue 番号"
+            />
+            <select
+              aria-label="Issue 対応の権限モード"
+              value={issueMode}
+              onChange={(e) => setIssueMode(e.target.value as PermissionMode)}
+            >
+              {PERMISSION_MODE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="prompt-runner__button prompt-runner__button--primary"
+              disabled={parsedIssueNumbers.length === 0 || isRunning}
+              onClick={() => {
+                if (issueMode === "bypassPermissions") {
+                  setIssueConfirmOpen(true);
+                } else {
+                  handleStartIssueRuns();
+                }
+              }}
+            >
+              開始
+            </button>
+            <button
+              type="button"
+              className="prompt-runner__button"
+              onClick={() => setIssueInputOpen(false)}
+            >
+              閉じる
+            </button>
+          </div>
+          <p className="issue-runner__hint">
+            各 issue を gh CLI で確認し、実装 → テスト → PR
+            作成まで順に自動で行います。PR 作成（git/gh
+            の実行）まで任せるには「全許可」が必要です。
+          </p>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="issue-runner__toggle"
+          onClick={() => setIssueInputOpen(true)}
+          disabled={!cliAvailable}
+        >
+          ▷ GitHub Issue をまとめて対応…
+        </button>
+      )}
+
       {/* 会話エリア */}
       <div
         className="prompt-runner__log"
@@ -652,6 +771,20 @@ export const PromptRunner: React.FC<PromptRunnerProps> = ({
           </div>
         </div>
       </div>
+
+      <SafeConfirmDialog
+        isOpen={issueConfirmOpen}
+        title="全許可モードで issue 対応を開始しますか？"
+        message="issue の実装から PR 作成までを確認なしで実行します。ファイル変更・コミット・push・PR 作成が自動で行われます。開始してよろしいですか？"
+        confirmText="開始する"
+        cancelText="キャンセル"
+        variant="danger"
+        onConfirm={() => {
+          setIssueConfirmOpen(false);
+          handleStartIssueRuns();
+        }}
+        onCancel={() => setIssueConfirmOpen(false)}
+      />
 
       <SafeConfirmDialog
         isOpen={confirmOpen}

--- a/src/contexts/PromptRunsContext.tsx
+++ b/src/contexts/PromptRunsContext.tsx
@@ -100,6 +100,15 @@ export const EMPTY_CONVERSATION: PromptConversation = {
   activeRunId: null,
 };
 
+/** GitHub issue 対応キューの状態（プロジェクトごと） */
+export interface IssueQueueState {
+  /** 現在対応中の issue 番号（null は待機中） */
+  active: number | null;
+  /** これから対応する issue 番号 */
+  pending: number[];
+  permissionMode: PermissionMode;
+}
+
 interface PromptRunsContextValue {
   /** すべての実行（開始が新しい順） */
   runs: PromptRunInfo[];
@@ -108,6 +117,8 @@ interface PromptRunsContextValue {
   latestRunByProject: Map<string, PromptRunInfo>;
   /** プロジェクトごとの会話ログ */
   conversations: Map<string, PromptConversation>;
+  /** プロジェクトごとの issue 対応キュー */
+  issueQueues: Map<string, IssueQueueState>;
   registerRun: (runId: string, meta: RegisterRunMeta) => void;
   stopRun: (runId: string) => Promise<void>;
   /** プロンプトを送信する（会話へのエントリ追加〜実行登録まで担う） */
@@ -117,6 +128,17 @@ interface PromptRunsContextValue {
   ) => Promise<string | null>;
   /** 会話ログをクリアして新しい会話を始める */
   resetConversation: (projectPath: string) => void;
+  /**
+   * GitHub issue 番号のキューを登録し、順次 claude に対応させる。
+   * 各 issue は新しい会話（独立したセッション）で実行される。
+   */
+  startIssueRuns: (
+    projectPath: string,
+    issueNumbers: number[],
+    permissionMode: PermissionMode,
+  ) => void;
+  /** 未着手の issue キューを取り消す（実行中の issue は停止しない） */
+  cancelIssueQueue: (projectPath: string) => void;
 }
 
 const PromptRunsContext = createContext<PromptRunsContextValue | null>(null);
@@ -128,6 +150,24 @@ const PENDING_EVENT_LIMIT = 300;
 
 /** SIGTERM（停止ボタン）による終了コード */
 const SIGTERM_EXIT_CODE = 143;
+
+/**
+ * issue 対応の指示テンプレート。
+ * issue の取得は認証済みの gh CLI に任せるため、アプリ側に
+ * GitHub トークンは不要（プロジェクトの cwd で claude が実行する）。
+ */
+export function buildIssuePrompt(issueNumber: number): string {
+  return [
+    `GitHub issue #${issueNumber} に対応してください。`,
+    "",
+    `1. \`gh issue view ${issueNumber}\` で issue の内容と要求を確認する`,
+    "2. 現在のブランチが main / develop / staging の場合は、作業用ブランチを作成する",
+    "3. issue の内容を実装し、テスト・型チェックが通ることを確認する",
+    `4. コミットして push し、\`gh pr create\` で PR を作成する（本文に \`close #${issueNumber}\` を記載する）`,
+    "",
+    "不明点があり進められない場合は、判断に必要な情報と選択肢を整理して報告してください。",
+  ].join("\n");
+}
 
 function summarizeToolInput(input: Record<string, unknown>): string {
   const keys = ["file_path", "command", "pattern", "path", "prompt"] as const;
@@ -495,6 +535,13 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
   const pendingRef = useRef<Map<string, PromptRunEvent[]>>(new Map());
   const pendingCountRef = useRef(0);
 
+  // GitHub issue 対応キュー（プロジェクトごと・順次実行）。
+  // 同一ワーキングツリーで複数の claude が同時に編集すると git が
+  // 衝突するため、プロジェクト内は 1 件ずつ処理する
+  const issueQueuesRef = useRef<Map<string, IssueQueueState>>(new Map());
+  // handleEvent（先に定義）から後続定義の advanceIssueQueue を呼ぶための ref
+  const advanceIssueQueueRef = useRef<(projectPath: string) => void>(() => {});
+
   const trimFinished = useCallback(() => {
     const runs = runsRef.current;
     const finished = [...runs.values()]
@@ -545,7 +592,22 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
         info.projectPath,
         applyConversationEvent(conversation, event),
       );
-      if (event.kind === "exit") trimFinished();
+      if (event.kind === "exit") {
+        trimFinished();
+        // issue 対応キュー: 実行が終わったら次の issue へ進める
+        const queue = issueQueuesRef.current.get(info.projectPath);
+        if (queue) {
+          if (queue.pending.length === 0) {
+            issueQueuesRef.current.delete(info.projectPath);
+          } else {
+            issueQueuesRef.current.set(info.projectPath, {
+              ...queue,
+              active: null,
+            });
+            advanceIssueQueueRef.current(info.projectPath);
+          }
+        }
+      }
       bump();
     },
     [bump, trimFinished],
@@ -698,6 +760,91 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
     [bump],
   );
 
+  /** キューの先頭の issue を（会話が空いていれば）実行に移す */
+  const advanceIssueQueue = useCallback(
+    (projectPath: string) => {
+      const queues = issueQueuesRef.current;
+      const queue = queues.get(projectPath);
+      if (!queue) return;
+
+      const conversation =
+        conversationsRef.current.get(projectPath) ?? EMPTY_CONVERSATION;
+      if (conversation.isRunning) return; // exit 時に再度呼ばれる
+
+      const next = queue.pending[0];
+      if (next === undefined) {
+        queues.delete(projectPath);
+        bump();
+        return;
+      }
+
+      queues.set(projectPath, {
+        ...queue,
+        active: next,
+        pending: queue.pending.slice(1),
+      });
+      // 各 issue は独立した会話（新しいセッション）で対応する
+      resetConversation(projectPath);
+      void sendPrompt(projectPath, {
+        prompt: buildIssuePrompt(next),
+        permissionMode: queue.permissionMode,
+        model: null,
+      }).then((failure) => {
+        if (failure) {
+          // 起動に失敗（CLI 不在等）: 以降も失敗するためキューを止める。
+          // エラー内容は会話にエラー行として表示済み
+          issueQueuesRef.current.delete(projectPath);
+          bump();
+        }
+      });
+      bump();
+    },
+    [bump, resetConversation, sendPrompt],
+  );
+
+  useEffect(() => {
+    advanceIssueQueueRef.current = advanceIssueQueue;
+  }, [advanceIssueQueue]);
+
+  const startIssueRuns = useCallback(
+    (
+      projectPath: string,
+      issueNumbers: number[],
+      permissionMode: PermissionMode,
+    ) => {
+      const unique = [...new Set(issueNumbers)].filter(
+        (n) => Number.isInteger(n) && n > 0,
+      );
+      if (unique.length === 0) return;
+      issueQueuesRef.current.set(projectPath, {
+        active: null,
+        pending: unique,
+        permissionMode,
+      });
+      bump();
+      advanceIssueQueue(projectPath);
+    },
+    [bump, advanceIssueQueue],
+  );
+
+  const cancelIssueQueue = useCallback(
+    (projectPath: string) => {
+      const queue = issueQueuesRef.current.get(projectPath);
+      if (!queue) return;
+      const conversation =
+        conversationsRef.current.get(projectPath) ?? EMPTY_CONVERSATION;
+      if (conversation.isRunning && queue.active !== null) {
+        // 実行中の issue はそのまま（停止はユーザーが明示的に行う）。
+        // 未着手分だけ取り消す
+        issueQueuesRef.current.set(projectPath, { ...queue, pending: [] });
+      } else {
+        issueQueuesRef.current.delete(projectPath);
+      }
+      bump();
+    },
+    [bump],
+  );
+
   useEffect(() => {
     let disposed = false;
     let unlisten: (() => void) | undefined;
@@ -737,12 +884,23 @@ export const PromptRunsProvider: React.FC<{ children: React.ReactNode }> = ({
       runningCount: runs.filter((r) => r.status === "running").length,
       latestRunByProject,
       conversations: new Map(conversationsRef.current),
+      issueQueues: new Map(issueQueuesRef.current),
       registerRun,
       stopRun,
       sendPrompt,
       resetConversation,
+      startIssueRuns,
+      cancelIssueQueue,
     };
-  }, [version, registerRun, stopRun, sendPrompt, resetConversation]);
+  }, [
+    version,
+    registerRun,
+    stopRun,
+    sendPrompt,
+    resetConversation,
+    startIssueRuns,
+    cancelIssueQueue,
+  ]);
 
   return (
     <PromptRunsContext.Provider value={value}>

--- a/src/contexts/__tests__/IssueQueue.test.tsx
+++ b/src/contexts/__tests__/IssueQueue.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * GitHub issue 対応キュー（issue #12）のテスト。
+ * 複数 issue の順次実行・各 issue の独立セッション・キャンセルを確認する。
+ */
+import { render, act, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import React from "react";
+import {
+  PromptRunsProvider,
+  usePromptRuns,
+  buildIssuePrompt,
+} from "../PromptRunsContext";
+import { api } from "../../api";
+import type { PromptRunEvent } from "../../types";
+
+vi.mock("../../api");
+const mockApi = vi.mocked(api);
+
+let handlers: Set<(event: PromptRunEvent) => void> = new Set();
+
+const emit = (event: PromptRunEvent): void => {
+  act(() => {
+    for (const handler of handlers) handler(event);
+  });
+};
+
+let store: ReturnType<typeof usePromptRuns> | null = null;
+
+const getStore = (): ReturnType<typeof usePromptRuns> => {
+  if (!store) throw new Error("store is not mounted");
+  return store;
+};
+
+const Harness: React.FC = () => {
+  store = usePromptRuns();
+  return null;
+};
+
+const PROJECT = "/Users/john/projects/alpha";
+
+describe("Issue queue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers = new Set();
+    store = null;
+
+    let runSeq = 0;
+    mockApi.startPromptRun.mockImplementation(async () => {
+      runSeq += 1;
+      return `run-${runSeq}`;
+    });
+    mockApi.onPromptRunEvent.mockImplementation(async (handler) => {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    });
+
+    render(
+      <PromptRunsProvider>
+        <Harness />
+      </PromptRunsProvider>,
+    );
+  });
+
+  it("buildIssuePrompt は gh CLI の利用と PR 作成を指示する", () => {
+    const prompt = buildIssuePrompt(42);
+    expect(prompt).toContain("gh issue view 42");
+    expect(prompt).toContain("close #42");
+    expect(prompt).toContain("gh pr create");
+  });
+
+  it("複数 issue を順次実行し、各 issue は新しい会話で対応する", async () => {
+    act(() => {
+      getStore().startIssueRuns(PROJECT, [12, 34], "acceptEdits");
+    });
+
+    // 1 件目（#12）が送信される
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledTimes(1);
+    });
+    expect(mockApi.startPromptRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        projectPath: PROJECT,
+        prompt: expect.stringContaining("#12"),
+        permissionMode: "acceptEdits",
+        resumeSessionId: null,
+      }),
+    );
+
+    // キュー表示: #12 が対応中、#34 が残り
+    let queue = getStore().issueQueues.get(PROJECT);
+    expect(queue?.active).toBe(12);
+    expect(queue?.pending).toEqual([34]);
+
+    // #12 の実行にセッションが付き、完了する
+    emit({
+      run_id: "run-1",
+      kind: "message",
+      payload: { type: "system", subtype: "init", session_id: "sess-issue-12" },
+    });
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+
+    // 2 件目（#34）が新しい会話（resumeSessionId: null）で送信される
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledTimes(2);
+    });
+    expect(mockApi.startPromptRun).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining("#34"),
+        resumeSessionId: null,
+      }),
+    );
+
+    queue = getStore().issueQueues.get(PROJECT);
+    expect(queue?.active).toBe(34);
+    expect(queue?.pending).toEqual([]);
+
+    // #34 も完了するとキューは消える
+    emit({ run_id: "run-2", kind: "exit", exit_code: 0, success: true });
+    expect(getStore().issueQueues.get(PROJECT)).toBeUndefined();
+  });
+
+  it("残りをキャンセルすると未着手分だけ取り消される", async () => {
+    act(() => {
+      getStore().startIssueRuns(PROJECT, [12, 34, 56], "plan");
+    });
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      getStore().cancelIssueQueue(PROJECT);
+    });
+
+    // 実行中の #12 は残り、pending は空
+    const queue = getStore().issueQueues.get(PROJECT);
+    expect(queue?.active).toBe(12);
+    expect(queue?.pending).toEqual([]);
+
+    // #12 が終わってもキューは消え、次は実行されない
+    emit({ run_id: "run-1", kind: "exit", exit_code: 0, success: true });
+    expect(getStore().issueQueues.get(PROJECT)).toBeUndefined();
+    expect(mockApi.startPromptRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("起動失敗（CLI 不在等）でキューを止める", async () => {
+    mockApi.startPromptRun.mockRejectedValue(new Error("claude not found"));
+
+    act(() => {
+      getStore().startIssueRuns(PROJECT, [12, 34], "plan");
+    });
+
+    await waitFor(() => {
+      expect(getStore().issueQueues.get(PROJECT)).toBeUndefined();
+    });
+    // 2 件目は実行されない
+    expect(mockApi.startPromptRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("重複と不正な番号は除外される", async () => {
+    act(() => {
+      getStore().startIssueRuns(PROJECT, [12, 12, -1, 0, 34], "plan");
+    });
+    await waitFor(() => {
+      expect(mockApi.startPromptRun).toHaveBeenCalledTimes(1);
+    });
+    const queue = getStore().issueQueues.get(PROJECT);
+    expect(queue?.active).toBe(12);
+    expect(queue?.pending).toEqual([34]);
+  });
+});

--- a/src/styles/prompt-runner.css
+++ b/src/styles/prompt-runner.css
@@ -478,3 +478,81 @@
   outline: 2px solid var(--color-primary-500);
   outline-offset: 2px;
 }
+
+/* ---- GitHub issue 対応キュー（issue #12） ---- */
+
+.issue-runner {
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+}
+
+.issue-runner--active {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--color-primary-50);
+  border: 1px solid var(--color-primary-200);
+  color: var(--color-primary-700);
+  font-size: var(--font-size-sm);
+}
+
+.issue-runner--form {
+  background: var(--color-secondary-100);
+}
+
+.issue-runner__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.issue-runner__input {
+  flex: 1;
+  padding: 6px 10px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-size: var(--font-size-sm);
+}
+
+.issue-runner__input:focus {
+  outline: none;
+  border-color: var(--color-primary-500);
+}
+
+.issue-runner__controls select {
+  padding: 5px 8px;
+  background: #fff;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-gray-800);
+  font-size: var(--font-size-xs);
+}
+
+.issue-runner__hint {
+  margin: 6px 0 0;
+  color: var(--color-secondary-500);
+  font-size: var(--font-size-xs);
+}
+
+.issue-runner__toggle {
+  padding: 6px 12px;
+  background: none;
+  border: 1px dashed var(--color-gray-300);
+  border-radius: var(--radius-sm);
+  color: var(--color-primary-600);
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.issue-runner__toggle:hover:not(:disabled) {
+  background: var(--color-primary-50);
+  border-color: var(--color-primary-300);
+}
+
+.issue-runner__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}


### PR DESCRIPTION
## 概要

issue #12「github issue番号を列挙したら、それぞれのclaudeを立ち上げ、issueの対応をしてくれる機能がほしい」の実装です。

Prompt タブに「▷ GitHub Issue をまとめて対応…」を追加。issue 番号を列挙（例: `12, 34`）すると、各 issue に claude が**順次**対応します（内容確認 → 実装 → テスト → ブランチ作成 → `close #N` 付き PR 作成まで）。

## 設計判断

| 論点 | 判断 |
|---|---|
| **GitHub トークン** | **不要**。issue の取得は認証済みの `gh` CLI に任せる（claude がプロジェクトの cwd で `gh issue view N` を実行）。issue 本文にあった「token が必要になるかも。そのときは相談してほしい」の懸念はこの方式で回避しました |
| **並行 vs 順次** | プロジェクト内は**順次キュー**。同一ワーキングツリーで複数の claude が同時に編集すると git が衝突するため。プロジェクト間の並行は従来どおり可能（別プロジェクトで同時にキューを回せます） |
| **セッション** | 各 issue は**新しい会話（独立セッション）**で対応。issue ごとの会話が混ざらない |
| **権限モード** | ヘッドレス実行は対話的な許可プロンプトに答えられないため、PR 作成（git/gh 実行）まで任せるには「全許可」が必要。**既定を全許可にし、開始前に必ず危険確認ダイアログ**を挟みます。読み取り専用での「調査だけ」も選択可能 |

## 動作

- 実行中は `Issue 対応中: #12（残り 1 件: #34）` を表示、「残りをキャンセル」で未着手分のみ取り消し（実行中の issue は停止ボタンで個別停止）
- 1 件完了すると自動で次へ。全完了でキュー消滅
- 起動失敗（CLI 不在等）はキューを止め、エラーを会話に表示
- 実行状況は既存の Dashboard 状況ボード / Prompts タブにもそのまま反映されます

## 検証

- ユニットテスト 5 件追加（順次実行と独立セッション / キャンセル / 起動失敗時の停止 / 重複・不正番号の除外 / プロンプト内容）— 計 111 件通過
- ブラウザで一連のフロー（確認ダイアログ → #12 対応中 → 完了で #34 へ自動遷移 → キュー消滅、キャンセル）を確認

close #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
